### PR TITLE
Allow for parsing multiple datetimes

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -35,11 +35,11 @@ def test_choices(now):
         datetime.datetime(2018, 7, 17, 16, 0),
         datetime.datetime(2018, 7, 17, 17, 0),
     ]
-    assert timefhuman('7/17 4-5 PM or 5-6 PM') == [
+    assert timefhuman('7/17 4-5 PM or 5-6 PM', now) == [
         (datetime.datetime(2018, 7, 17, 16, 0), datetime.datetime(2018, 7, 17, 17, 0)),
         (datetime.datetime(2018, 7, 17, 17, 0), datetime.datetime(2018, 7, 17, 18, 0))
     ]
-    assert timefhuman('7/17 4-5 or 5-6 PM') == [
+    assert timefhuman('7/17 4-5 or 5-6 PM', now) == [
         (datetime.datetime(2018, 7, 17, 16, 0), datetime.datetime(2018, 7, 17, 17, 0)),
         (datetime.datetime(2018, 7, 17, 17, 0), datetime.datetime(2018, 7, 17, 18, 0))
     ]
@@ -61,7 +61,7 @@ def test_edge_cases_range(now):
     assert timefhuman('7/17-7/18', now) == (
         datetime.datetime(2018, 7, 17, 0, 0),
         datetime.datetime(2018, 7, 18, 0, 0),)
-    assert timefhuman('7/17 3 pm- 7/19 2 pm') == (
+    assert timefhuman('7/17 3 pm- 7/19 2 pm', now) == (
         datetime.datetime(2018, 7, 17, 15, 0),
         datetime.datetime(2018, 7, 19, 14, 0),)
 
@@ -72,3 +72,15 @@ def test_comma_delimited_combination(now):
         datetime.datetime(2018, 8, 8, 15, 0),
         datetime.datetime(2018, 8, 10, 11, 0)
     ]
+
+def test_multiple_datetimes(now):
+    assert timefhuman('Jun 28 5:00 PM - Aug 02 7:00 PM', now) == \
+        (datetime.datetime(2018, 6, 28, 17, 0), datetime.datetime(2018, 8, 2, 19, 0))
+    assert timefhuman('Jun 28 2019 5:00 PM - Aug 02 2019 7:00 PM', now) == \
+        (datetime.datetime(2019, 6, 28, 17, 0), datetime.datetime(2019, 8, 2, 19, 0))
+    assert timefhuman('Jun 28, 2019 5:00 PM - Aug 02, 2019 7:00 PM', now) == \
+        (datetime.datetime(2019, 6, 28, 17, 0), datetime.datetime(2019, 8, 2, 19, 0))
+    assert timefhuman('6/28 5:00 PM - 8/02 7:00 PM', now) == \
+        (datetime.datetime(2018, 6, 28, 17, 0), datetime.datetime(2018, 8, 2, 19, 0))
+    assert timefhuman('6/28/2019 5:00 PM - 8/02/2019 7:00 PM', now) == \
+        (datetime.datetime(2019, 6, 28, 17, 0), datetime.datetime(2019, 8, 2, 19, 0))

--- a/timefhuman/categorize.py
+++ b/timefhuman/categorize.py
@@ -216,11 +216,11 @@ def maybe_substitute_using_month(tokens, now=datetime.datetime.now()):
             return tokens[:index] + [day] + tokens[index+2:]
         elif not next_next_candidate.isnumeric():
             day = DayToken(month=mo, day=next_candidate, year=now.year)
-            return tokens[:index] + [day] + tokens[index+2:]
+            return maybe_substitute_using_month(tokens[:index] + [day] + tokens[index+2:], now)
 
         next_next_candidate = int(next_next_candidate)
         day = DayToken(month=mo, day=next_candidate, year=next_next_candidate)
-        return tokens[:index] + [day] + tokens[index+3:]
+        return maybe_substitute_using_month(tokens[:index] + [day] + tokens[index+3:], now)
     return tokens
 
 

--- a/timefhuman/categorize.py
+++ b/timefhuman/categorize.py
@@ -158,7 +158,7 @@ def maybe_substitute_using_month(tokens, now=datetime.datetime.now()):
     """
 
     >>> now = datetime.datetime(year=2018, month=7, day=7)
-    >>> maybe_substitute_using_month(['July', '17', ',', '2018', 'at'])
+    >>> maybe_substitute_using_month(['July', '17', ',', '2018', 'at'], now=now)
     [7/17/2018, 'at']
     >>> maybe_substitute_using_month(['Jul', '17', 'at'], now=now)
     [7/17/2018, 'at']
@@ -174,7 +174,7 @@ def maybe_substitute_using_month(tokens, now=datetime.datetime.now()):
     >>> day_range = DayRange(DayToken(None, 3, None), DayToken(None, 5, None))
     >>> day = DayToken(3, 5, 2018)
     >>> ambiguous_token = AmbiguousToken(time_range, day, day_range)
-    >>> maybe_substitute_using_month(['May', ambiguous_token])
+    >>> maybe_substitute_using_month(['May', ambiguous_token], now=now)
     [5/3/2018 - 5/5/2018]
     """
     temp_tokens = [token.lower() if isinstance(token, str) else token for token in tokens]

--- a/timefhuman/data.py
+++ b/timefhuman/data.py
@@ -18,6 +18,9 @@ class Token:
             setter(self, property, others)
         elif others is None and mine is not None:
             setter(other, property, mine)
+    
+    def isnumeric(self):
+        return False
 
 
 class ListToken(Token):

--- a/timefhuman/main.py
+++ b/timefhuman/main.py
@@ -47,9 +47,9 @@ def timefhuman(string, now=None, raw=None):
     [datetime.datetime(2018, 7, 17, 15, 0), datetime.datetime(2018, 7, 18, 15, 0)]
     >>> timefhuman('today or tomorrow noon', now=now)  # choices w. natural language
     [datetime.datetime(2018, 8, 4, 12, 0), datetime.datetime(2018, 8, 5, 12, 0)]
-    >>> timefhuman('2 PM on 7/17 or 7/19')  # time applies to both dates
+    >>> timefhuman('2 PM on 7/17 or 7/19', now=now)  # time applies to both dates
     [datetime.datetime(2018, 7, 17, 14, 0), datetime.datetime(2018, 7, 19, 14, 0)]
-    >>> timefhuman('2 PM on 7/17 or 7/19', raw=True)
+    >>> timefhuman('2 PM on 7/17 or 7/19', raw=True, now=now)
     [[7/17/2018 2 pm, 7/19/2018 2 pm]]
     """
     if now is None:


### PR DESCRIPTION
First of all, thanks for making this library. It's been a huge help for my web scraping project. 

I've fixed a few bugs in this pull request.

1. Token classes don't have the `isnumeric` attribute, so an exception was being thrown on line 210 of `categorize.py` under certain circumstances. One example that causes this is `timefhuman('Jun 28 5:00 PM - Aug 02 7:00 PM')`.

2. `maybe_substitute_using_month` stopped iterating after the first substitution so multiple datetimes didn't get substituted completely. I've added recursive calls in this function to fix this.

3. A few tests were missing the `now` parameter, causing the years to get messed up. I've added the parameter to these missing calls.

Let me know if you need me to change anything, thanks.