### PR TITLE
remove suffix from day

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,3 +1,3 @@
 from timefhuman import timefhuman
-print(timefhuman('7/17-7/18'))
+print(timefhuman('october 27th'))
 

--- a/timefhuman/tokenize.py
+++ b/timefhuman/tokenize.py
@@ -1,5 +1,5 @@
+import re
 import string
-
 
 def tokenize(characters):
     """Tokenize all characters in the string.
@@ -11,10 +11,12 @@ def tokenize(characters):
     >>> list(tokenize('7/17, 7/18, 7/19 at 2'))
     ['7/17', ',', '7/18', ',', '7/19', 'at', '2']
     """
-    tokens = generic_tokenize(characters)
+    tokens = generic_tokenize(remove_day_suffix(characters))
     tokens = clean_dash_tokens(tokens)
     return tokens
 
+def remove_day_suffix(characters):
+    return re.sub(r'(\d+)(th|st|nd|rd)', '\g<1>', characters)
 
 def generic_tokenize(characters):
     """Default tokenizer


### PR DESCRIPTION
This is related with #10 

The problem that occur with the "march 20th" case was because the "th" was mistake by "Thursday"

To fix I removed all suffix from the day (like 20th, 1st, 2nd) before extract the tokens from the string.
This way this problem was avoid