### PR TITLE
o'clock fix

### DIFF
--- a/timefhuman/categorize.py
+++ b/timefhuman/categorize.py
@@ -109,7 +109,6 @@ def convert_relative_days(tokens, now=datetime.datetime.now()):
     return tokens
 
 
-
 # TODO: convert to new token-based system
 def extract_weeks_offset(tokens, end=None, key_tokens=(
         'next', 'previous', 'last', 'upcoming', 'past', 'prev')):
@@ -341,6 +340,12 @@ def extract_hour_minute_token(tokens, time_of_day=None):
         This will either be 1 before or 2 before the am/pm token.
         12:00 is the default token to prevent failure
         Tests for this helper function are included in maybe_substitute_hour_minute
+        >>> extract_hour_minute_token(["3", "o'clock"])
+        -2, 3
+        >>> extract_hour_minute_token(["Gibberish", "twice"])
+        -1, 12
+        >>> extract_hour_minute_token(["only one value"])
+        -1 12
     """
 
     # look at previous n tokens
@@ -355,7 +360,7 @@ def extract_hour_minute_token(tokens, time_of_day=None):
         except IndexError:
             pass
     # default return value
-    return -1, "12:00"
+    return -1, 12
 
 
 def maybe_substitute_hour_minute(tokens):

--- a/timefhuman/categorize.py
+++ b/timefhuman/categorize.py
@@ -332,7 +332,7 @@ def extract_hour_minute_token(tokens, time_of_day=None):
             current_token = tokens[-i]
             if current_token.lower() in number_words:
                 current_token = str(number_words.index(current_token.lower()))
-            return tokens[:-i-1], extract_hour_minute(current_token, time_of_day)
+            return -i, extract_hour_minute(current_token, time_of_day)
         # if nothing is returned from extract_hour_minute
         except ValueError:
             pass
@@ -340,7 +340,7 @@ def extract_hour_minute_token(tokens, time_of_day=None):
         except IndexError:
             pass
     # default return value
-    return tokens, "12:00"
+    return -1, "12:00"
 
 
 def maybe_substitute_hour_minute(tokens):
@@ -374,8 +374,8 @@ def maybe_substitute_hour_minute(tokens):
     for time_of_day in ('am', 'pm'):
         while time_of_day in temp_tokens:
             index = temp_tokens.index(time_of_day)
-            (previous_tokens, time_token) = extract_hour_minute_token(temp_tokens[:index], time_of_day)
-            tokens = previous_tokens + [time_token] + tokens[index+1:]
+            (unchanged_index, time_token) = extract_hour_minute_token(temp_tokens[:index], time_of_day)
+            tokens = tokens[:index+unchanged_index] + [time_token] + tokens[index+1:]
             temp_tokens = clean_tokens(tokens, remove_dots)
 
     tokens = [extract_hour_minute(token, None)


### PR DESCRIPTION
#12 

Fix parsing of "5 o'clock pm", "five o'clock pm" and "five o'clock".
Create a separate function to convert all word numbers to digit numbers. 
Add 2 tests for new function and 2 extra tests to `maybe_substitute_hour_minute` function.
All tests on pytest passing.

