### PR TITLE
Add more python versions to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 
 python:
   - "3.6.2"
+  - "3.7.7"
+  - "3.8.2"
 
 install:
   - python setup.py install


### PR DESCRIPTION
This should help support a few more versions of Python. I'm currently having issues on 3.8.2 and I wonder if it's something on my end.