### PR TITLE
[durations] Fix overeager duration unit, support duration lists and ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ class tfhConfig:
 
 ## Development
 
+Install the development version.
+
+```shell
+$ pip install .e .[test]  # for bash
+$ pip install -e .\[test\]  # for zsh
+```
+
 To run tests and simultaneously generate a coverage report, use the following commands:
 
 ```shell

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -104,7 +104,7 @@ def test_default(now, test_input, expected):
     ('in five minutes', datetime.timedelta(minutes=5)), # gh#25
     ('awk', []),  # should *not become 'a week'
     ('a wk', datetime.timedelta(days=7)),
-    # ('thirty two hours', datetime.timedelta(hours=32)), # TODO
+    ('thirty two hours', datetime.timedelta(hours=32)),
     # ('one and a half hour', datetime.timedelta(hours=1, minutes=30)), # TODO
     # ('30-40 mins', (datetime.timedelta(minutes=30), datetime.timedelta(minutes=40))), # TODO: handle unidentifiable ints
     # ('1 or 2 days', [datetime.timedelta(days=1), datetime.timedelta(days=2)]), # TODO: handle unidentifiable ints

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -68,7 +68,7 @@ def now():
     
     ('7/17, 7/18, 7/19 at 2', [datetime.datetime(2018, 7, 17, 2, 0), datetime.datetime(2018, 7, 18, 2, 0), datetime.datetime(2018, 7, 19, 2, 0)]), # distribute dates
     ('2 PM on 7/17 or 7/19', [datetime.datetime(2018, 7, 17, 14, 0), datetime.datetime(2018, 7, 19, 14, 0)]), # distribute time across dates
-    # ('2022-12-27T09:15:00.000', datetime.datetime(2022, 12, 27, 9, 15)),  # TODO: support ISO 8601 (YMD)
+    # ('2022-12-27T09:15:00.000', datetime.datetime(2022, 12, 27, 9, 15)),  # TODO: support ISO 8601 (YMD) gh#31
 ])
 def test_default(now, test_input, expected):
     """Default behavior should be to infer datetimes and times."""

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -106,8 +106,8 @@ def test_default(now, test_input, expected):
     ('a wk', datetime.timedelta(days=7)),
     ('thirty two hours', datetime.timedelta(hours=32)),
     # ('one and a half hour', datetime.timedelta(hours=1, minutes=30)), # TODO
-    # ('30-40 mins', (datetime.timedelta(minutes=30), datetime.timedelta(minutes=40))), # TODO: handle unidentifiable ints
-    # ('1 or 2 days', [datetime.timedelta(days=1), datetime.timedelta(days=2)]), # TODO: handle unidentifiable ints
+    ('30-40 mins', (datetime.timedelta(minutes=30), datetime.timedelta(minutes=40))),
+    ('1 or 2 days', [datetime.timedelta(days=1), datetime.timedelta(days=2)]),
     # TODO: support duration ranges/lists
     # TODO: support natural language times like "3 o'clock" or "quarter to 3"
     

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -68,6 +68,7 @@ def now():
     
     ('7/17, 7/18, 7/19 at 2', [datetime.datetime(2018, 7, 17, 2, 0), datetime.datetime(2018, 7, 18, 2, 0), datetime.datetime(2018, 7, 19, 2, 0)]), # distribute dates
     ('2 PM on 7/17 or 7/19', [datetime.datetime(2018, 7, 17, 14, 0), datetime.datetime(2018, 7, 19, 14, 0)]), # distribute time across dates
+    # ('2022-12-27T09:15:00.000', datetime.datetime(2022, 12, 27, 9, 15)),  # TODO: support ISO 8601 (YMD)
 ])
 def test_default(now, test_input, expected):
     """Default behavior should be to infer datetimes and times."""

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -100,7 +100,10 @@ def test_default(now, test_input, expected):
     ('2h30m', datetime.timedelta(hours=2, minutes=30)),
     ('1 day and an hour', datetime.timedelta(days=1, hours=1)),
     ('1.5 hours', datetime.timedelta(hours=1, minutes=30)),
+    ('1.5h', datetime.timedelta(hours=1, minutes=30)),
     ('in five minutes', datetime.timedelta(minutes=5)), # gh#25
+    ('awk', []),  # should *not become 'a week'
+    ('a wk', datetime.timedelta(days=7)),
     # ('thirty two hours', datetime.timedelta(hours=32)), # TODO
     # ('one and a half hour', datetime.timedelta(hours=1, minutes=30)), # TODO
     # ('30-40 mins', (datetime.timedelta(minutes=30), datetime.timedelta(minutes=40))), # TODO: handle unidentifiable ints

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -79,9 +79,11 @@ def test_default(now, test_input, expected):
 @pytest.mark.parametrize("test_input, expected", [
     # time only
     ('5p', datetime.time(hour=17, minute=0)),
+    # ("3 o'clock", datetime.time(hour=3, minute=0)),
     
     # date only
     ('July 2019', datetime.date(2019, 7, 1)),
+    # ('Monday July 1, 2019', datetime.date(2019, 7, 1)),
     
     # date-only ranges
     ('7/17-7/18', (datetime.date(2018, 7, 17), datetime.date(2018, 7, 18))),
@@ -132,7 +134,7 @@ def test_no_inference(now, test_input, expected):
     # (tfhConfig(infer_datetimes=True), '1p', datetime.datetime(2018, 8, 5, 13, 0)), # TODO tomorrow, since passed today (gh#12)
 
     # TODO: add tests for 'next/last'
-])      
+])
 def test_custom_config(now, config, test_input, expected):
     config.now = now
     assert timefhuman(test_input, config=config) == expected

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -105,11 +105,14 @@ def test_default(now, test_input, expected):
     ('awk', []),  # should *not become 'a week'
     ('a wk', datetime.timedelta(days=7)),
     ('thirty two hours', datetime.timedelta(hours=32)),
-    # ('one and a half hour', datetime.timedelta(hours=1, minutes=30)), # TODO
+    
+    # duration ranges and lists
     ('30-40 mins', (datetime.timedelta(minutes=30), datetime.timedelta(minutes=40))),
     ('1 or 2 days', [datetime.timedelta(days=1), datetime.timedelta(days=2)]),
-    # TODO: support duration ranges/lists
-    # TODO: support natural language times like "3 o'clock" or "quarter to 3"
+
+    # TODO: support "3 o'clock"
+    # TODO: support "quarter to 3"
+    # TODO: support "one and a half hours"
     
     # TODO ('noon next week') <- should be a list of options
     # TODO: support recurrences, like "5pm on thursdays" (see gh#33)
@@ -138,6 +141,7 @@ def test_custom_config(now, config, test_input, expected):
 @pytest.mark.parametrize("test_input, expected", [
     ('September 30, 2019.', datetime.datetime(2019, 9, 30, 0, 0)), # gh#26
     ('How does 5p mon sound? Or maybe 4p tu?', [datetime.datetime(2018, 8, 6, 17, 0), datetime.datetime(2018, 8, 7, 16, 0)]),
+    ('There are 3 ways to do it', []),  # '3' should remain ambiguous and then be ignored
     # TODO: get matched characters
 ])
 def test_with_random_text(now, test_input, expected):

--- a/timefhuman/grammar.lark
+++ b/timefhuman/grammar.lark
@@ -84,7 +84,7 @@ duration: ("in"|"for")? duration_part (("and"|",")? duration_part)* ("ago")?
 duration_part: duration_number (duration_unit | duration_unit_letter)
              | duration_numbername " " duration_unit
 duration_number: FLOAT_NUMBER | INT
-duration_numbername: DURATION_NUMBER
+duration_numbername: DURATION_NUMBER+
 duration_unit: DURATION_UNIT
 duration_unit_letter: DURATION_UNIT_LETTER
 

--- a/timefhuman/grammar.lark
+++ b/timefhuman/grammar.lark
@@ -22,13 +22,16 @@ DATENAME: /(?i)(today|tomorrow|tmw|yesterday)/
 TIMENAME: /(?i)(noon|midday|midnight)/
 
 // Duration unit (minutes, hours, days, etc.)
-DURATION_UNIT: /(?i)(minutes|mins|min|m|hours|hour|hrs|hr|h|days|day|d|weeks|week|wks|wk|months|month|mos|years|years)/
+DURATION_UNIT: /(?i)(seconds|second|secs|sec|minutes|mins|min|hours|hour|hrs|hr|h|days|day|weeks|week|wks|wk|months|month|mos|years|year)/
+DURATION_UNIT_LETTER: /(?i)(s|m|h|d|w|mo|y)/
 
 // Duration number (digits like "1", or words like "an", "a", "one", "two", etc.)
-DURATION_NUMBER: /(?i)(an|a|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety|[0-9]+(\.[0-9]+)?)/
+DURATION_NUMBER: /(?i)(an|a|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety)/
 
 // Day suffix (th, rd, st, nd)
 DAY_SUFFIX: /(?i)(th|rd|st|nd)/
+
+FLOAT_NUMBER: /((\d+\.\d*|\.\d+)(e[-+]?\d+)?|\d+(e[-+]?\d+))/i  // from lark
 
 // ----------------------
 // PARSER RULES
@@ -78,9 +81,12 @@ time: hour ":" minute meridiem?
     | timename
 
 duration: ("in"|"for")? duration_part (("and"|",")? duration_part)* ("ago")?
-duration_part: duration_number duration_unit
-duration_number: DURATION_NUMBER
+duration_part: duration_number (duration_unit | duration_unit_letter)
+             | duration_numbername " " duration_unit
+duration_number: FLOAT_NUMBER | INT
+duration_numbername: DURATION_NUMBER
 duration_unit: DURATION_UNIT
+duration_unit_letter: DURATION_UNIT_LETTER
 
 weekday: WEEKDAY
 monthname: MONTHNAME

--- a/timefhuman/grammar.lark
+++ b/timefhuman/grammar.lark
@@ -23,7 +23,7 @@ TIMENAME: /(?i)(noon|midday|midnight)/
 
 // Duration unit (minutes, hours, days, etc.)
 DURATION_UNIT: /(?i)(seconds|second|secs|sec|minutes|mins|min|hours|hour|hrs|hr|h|days|day|weeks|week|wks|wk|months|month|mos|years|year)/
-DURATION_UNIT_LETTER: /(?i)(s|m|h|d|w|mo|y)/
+DURATION_UNIT_LETTER: /(?i)(s|m|h|d|w|mo|y)(?![a-z])/
 
 // Duration number (digits like "1", or words like "an", "a", "one", "two", etc.)
 DURATION_NUMBER: /(?i)(an|a|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety)/

--- a/timefhuman/main.py
+++ b/timefhuman/main.py
@@ -320,11 +320,12 @@ def timefhuman(string, config: tfhConfig = tfhConfig(), raw=None):
     
     # TODO: add option to return with the original unknown tokens?
     # helps the user understand which tokens were not matched
+    # TODO: better way to filter 
     # NOTE: intentionally did not filter by hasattr(result, 'to_object') to 
     # catch any other objects that might be returned
     results = list(filter(
-        lambda s: isinstance(s, (datetime, date, time, timedelta)),
-        [result.to_object(config) for result in results]
+        lambda s: not isinstance(s, str),
+        [result.to_object(config) for result in results if not isinstance(result, str)]
     ))
     
     if len(results) == 1:

--- a/timefhuman/main.py
+++ b/timefhuman/main.py
@@ -425,7 +425,8 @@ class tfhTransformer(Transformer):
             'eighty': 80,
             'ninety': 90,
         }
-        data['duration_number'] = mapping.get(data['duration_number'], data['duration_number'])
+        duration_number = mapping[data['duration_numbername']] if 'duration_numbername' in data else float(data['duration_number'])
+        duration_unit = data.get('duration_unit', data.get('duration_unit_letter', None))
         for group in (
             ('minutes', 'minute', 'mins', 'min', 'm'),
             ('hours', 'hour', 'hrs', 'hr', 'h'),
@@ -434,8 +435,8 @@ class tfhTransformer(Transformer):
             ('months', 'month', 'mos'),
             ('years', 'year', 'yrs', 'yr'),
         ):
-            if data['duration_unit'] in group:
-                return timedelta(**{group[0]: float(data['duration_number'])})
+            if duration_unit in group:
+                return timedelta(**{group[0]: duration_number})
         raise NotImplementedError(f"Unknown duration unit: {data['duration_unit']}")
 
     def datetime(self, children):

--- a/timefhuman/main.py
+++ b/timefhuman/main.py
@@ -25,7 +25,7 @@ class tfhConfig:
     now: datetime = datetime.now()
 
 
-class tfhResult:
+class tfhDatelike:
     """
     A result is a single object that can be converted to a datetime, date, or time.
     
@@ -47,7 +47,7 @@ class tfhResult:
         raise NotImplementedError("Subclass must implement from_object()")
 
 
-class tfhCollection(tfhResult):
+class tfhCollection(tfhDatelike):
     def __init__(self, items):
         self.items = items
     
@@ -147,7 +147,7 @@ class tfhList(tfhCollection):
         return f"tfhList({self.items})"
 
 
-class tfhTimedelta(tfhResult):
+class tfhTimedelta:
     def __init__(self, days: int = 0, seconds: int = 0):
         self.days = days
         self.seconds = seconds
@@ -218,7 +218,7 @@ class tfhTime:
                 f"hour={self.hour}, minute={self.minute}, meridiem={self.meridiem})")
 
 
-class tfhDatetime(tfhResult):
+class tfhDatetime(tfhDatelike):
     """A combination of tfhDate + tfhTime."""
     
     @property
@@ -319,10 +319,11 @@ def timefhuman(string, config: tfhConfig = tfhConfig(), raw=None):
     return results
 
 
-def infer_from(source: tfhResult, target: tfhResult):
-    if isinstance(source, tfhAmbiguous) and not isinstance(target, tfhAmbiguous):
+def infer_from(source: tfhDatelike, target: tfhDatelike):
+    if isinstance(source, tfhAmbiguous):
+        # NOTE: Ambiguous tokens have no information to offer
         return target
-    if isinstance(target, tfhAmbiguous) and not isinstance(source, tfhAmbiguous):
+    if isinstance(target, tfhAmbiguous) and isinstance(source, tfhDatelike):
         if source.time:
             target = tfhDatetime(time=tfhTime(hour=target.value, meridiem=source.meridiem))
         elif source.year:
@@ -333,19 +334,17 @@ def infer_from(source: tfhResult, target: tfhResult):
             target = tfhDatetime(date=tfhDate(month=target.value))
         else:
             raise NotImplementedError(f"Not enough context to infer what {target} is")
-    if isinstance(source, tfhAmbiguous) and isinstance(target, tfhAmbiguous):
-        # NOTE: nothing we can do here. both are ambiguous.
-        return target
-    if source.date and not target.date:
-        target.date = source.date
-    if source.time and not target.time:
-        target.time = source.time
-    if source.month and not target.month:
-        target.month = source.month
-    if source.year and not target.year:
-        target.year = source.year
-    if source.meridiem and not target.meridiem:
-        target.meridiem = source.meridiem
+    if isinstance(source, tfhDatelike) and isinstance(target, tfhDatelike):
+        if source.date and not target.date:
+            target.date = source.date
+        if source.time and not target.time:
+            target.time = source.time
+        if source.month and not target.month:
+            target.month = source.month
+        if source.year and not target.year:
+            target.year = source.year
+        if source.meridiem and not target.meridiem:
+            target.meridiem = source.meridiem
     return target
 
 

--- a/timefhuman/main.py
+++ b/timefhuman/main.py
@@ -293,6 +293,14 @@ class tfhAmbiguous:
     
     def __init__(self, value: int):
         self.value = value
+        
+    def to_object(self, config: tfhConfig = tfhConfig()):
+        # NOTE: If the ambiguous token was never resolved, simply return the value as a str
+        return str(self.value)
+    
+    @classmethod
+    def from_object(cls, obj: int):
+        return cls(obj)
 
     def __repr__(self):
         return f"tfhAmbiguous({self.value})"
@@ -314,7 +322,11 @@ def timefhuman(string, config: tfhConfig = tfhConfig(), raw=None):
     # helps the user understand which tokens were not matched
     # NOTE: intentionally did not filter by hasattr(result, 'to_object') to 
     # catch any other objects that might be returned
-    results = [result.to_object(config) for result in results if not isinstance(result, str)]
+    results = list(filter(
+        lambda s: isinstance(s, (datetime, date, time, timedelta)),
+        [result.to_object(config) for result in results]
+    ))
+    
     if len(results) == 1:
         return results[0]
     return results

--- a/timefhuman/main.py
+++ b/timefhuman/main.py
@@ -393,7 +393,6 @@ class tfhTransformer(Transformer):
         return tfhTimedelta.from_object(sum(children, timedelta()))
     
     def duration_part(self, children):
-        data = {child.data.value: child.children[0].value for child in children}
         mapping = {
             'an': 1,
             'a': 1,
@@ -425,8 +424,11 @@ class tfhTransformer(Transformer):
             'eighty': 80,
             'ninety': 90,
         }
-        duration_number = mapping[data['duration_numbername']] if 'duration_numbername' in data else float(data['duration_number'])
-        duration_unit = data.get('duration_unit', data.get('duration_unit_letter', None))
+        # TODO: write my own multidict?
+        print(children)
+        data = {child.data.value: [_child.value for _child in child.children] for child in children}
+        duration_number = float(data['duration_number'][0]) if 'duration_number' in data else sum([mapping[value] for value in data.get('duration_numbername', [])])
+        duration_unit = data.get('duration_unit', data.get('duration_unit_letter', None))[0]
         for group in (
             ('minutes', 'minute', 'mins', 'min', 'm'),
             ('hours', 'hour', 'hrs', 'hr', 'h'),


### PR DESCRIPTION
- duration unit was matching substrings of unrelated works; now correctly requires space
- basic support for duration lists and ranges, with 'type' inference
- handle un-specified ambiguous tokens
- added some more tests to address