### PR TITLE
[dates] Account for 'redundant' weekday

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -87,7 +87,7 @@ def test_default(now, test_input, expected):
     
     # date only
     ('July 2019', datetime.date(2019, 7, 1)),
-    # ('Monday July 1, 2019', datetime.date(2019, 7, 1)),
+    ('Sunday 7/7/2019', datetime.date(2019, 7, 7)),  # fixes gh#27
     
     # date-only ranges
     ('7/17-7/18', (datetime.date(2018, 7, 17), datetime.date(2018, 7, 18))),

--- a/timefhuman/grammar.lark
+++ b/timefhuman/grammar.lark
@@ -51,8 +51,8 @@ list: single ((","|"or")+ single)+
     | range ((","|"or")+ range)+
 
 single: datetime 
-       | duration
-       | ambiguous
+      | duration
+      | ambiguous
 
 // Only add houronly to specific formats that immediately
 // indicate this is an hour-only time.
@@ -63,16 +63,16 @@ datetime: date ("at" (time | houronly))?
         | date
         | time
 
-date: month "/" day "/" year
-    | month "/" dayoryear
-    | month "-" day "-" year
-    | month "-" dayoryear
-    | datename
+date: weekday? month "/" day "/" year
+    | weekday? month "/" dayoryear
+    | weekday? month "-" day "-" year
+    | weekday? month "-" dayoryear
+    | weekday? datename
+    | weekday? monthname day DAY_SUFFIX? (",")? year
+    | weekday? monthname day DAY_SUFFIX
+    | weekday? day DAY_SUFFIX
+    | weekday? monthname dayoryear
     | weekday
-    | monthname day DAY_SUFFIX? (",")? year
-    | monthname day DAY_SUFFIX
-    | day DAY_SUFFIX
-    | monthname dayoryear
 
 // intentionally not allowing int-only time, so that single-integers can be
 // classified as an ambiguous token (in case it's a month, day, year, etc.)


### PR DESCRIPTION
Currently, parse weekdays like 'Sunday' as a date, and parse structured formats like '7/7' as a date as well. So if we specify 'Sunday 7/7', we'll get two datetimes, when they in fact just specify the same day redundantly. This fixes that, allowing 'redundant' weekday specification.