### PR TITLE
Get matched text

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,32 @@ See more examples in [`tests/test_e2e.py`](tests/test_e2e.py).
 
 ## Advanced Usage
 
-You can configure the default date that timefhuman uses to fill in missing information. This would be useful if you're extracting relative dates like `next Monday` from an email sent a year ago.
+For more configuration options, simply create a `tfhConfig` object.
 
 ```python
->>> from timefhuman import timefhuman, tfhConfig
->>> import datetime
+from timefhuman import tfhConfig
+config = tfhConfig()
+```
+
+**Return matched text**: You can additionally grab the matched text from the input string. This is useful for modifying the input string, for example.
+
+```python
+>>> config = tfhConfig(return_matched_text=True)
+
+>>> timefhuman('We could maybe do 3 PM, if you still have time', config=config)
+[('3 PM', datetime.datetime(2018, 8, 4, 15, 0))]
+```
+
+**Change 'Now'**: You can configure the default date that timefhuman uses to fill in missing information. This would be useful if you're extracting dates from an email sent a year ago.
+
+```python
 >>> config = tfhConfig(now=datetime.datetime(2018, 8, 4, 0, 0))
 
 >>> timefhuman('upcoming Monday noon', config=config)
 datetime.datetime(2018, 8, 6, 12, 0)
 ```
 
-Alternatively, say you want to extract only the time from a text -- perhaps it's a festival's schedule. You can disable date inference by setting `infer_datetimes=False`. Instead of always returning a datetime, timefhuman will be able to return time-like objects for only explicitly-written information.
+**Don't infer**: Alternatively, say you want to extract only the time from a text -- perhaps it's a festival's schedule. You can disable date inference by setting `infer_datetimes=False`. Instead of always returning a datetime, timefhuman will be able to return time-like objects for only explicitly-written information.
 
 ```python
 >>> config = tfhConfig(infer_datetimes=False)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -148,10 +148,10 @@ def test_custom_config(now, config, test_input, expected):
 
 
 @pytest.mark.parametrize("test_input, expected", [
-    ('September 30, 2019.', datetime.datetime(2019, 9, 30, 0, 0)), # gh#26
-    ('How does 5p mon sound? Or maybe 4p tu?', [datetime.datetime(2018, 8, 6, 17, 0), datetime.datetime(2018, 8, 7, 16, 0)]),
+    ('September 30, 2019.', [('September 30, 2019', datetime.datetime(2019, 9, 30, 0, 0))]), # gh#26
+    ('How does 5p mon sound? Or maybe 4p tu?', [('5p mon', datetime.datetime(2018, 8, 6, 17, 0)), ('4p tu', datetime.datetime(2018, 8, 7, 16, 0))]),
     ('There are 3 ways to do it', []),  # '3' should remain ambiguous and then be ignored
     # TODO: get matched characters gh#9
 ])
 def test_with_random_text(now, test_input, expected):
-    assert timefhuman(test_input, tfhConfig(now=now)) == expected
+    assert timefhuman(test_input, tfhConfig(now=now, return_matched_text=True)) == expected

--- a/timefhuman/grammar.lark
+++ b/timefhuman/grammar.lark
@@ -38,12 +38,11 @@ TIMEZONE: /(?i)((TIMEZONE_MAPPING))/
 // ----------------------
 // PARSER RULES
 // ----------------------
-start: expression
+start: (expression | unknown)+
 
-expression: (single
+expression: single
           | list
           | range
-          | unknown)+
 
 range: single ("to" | "-") single
 

--- a/timefhuman/renderers.py
+++ b/timefhuman/renderers.py
@@ -4,14 +4,18 @@ into native Python objects, such as datetime, date, time, and timedelta.
 """
 
 
-from typing import Optional, Union
+from typing import Optional, Union, Tuple
 from datetime import datetime, date, time, timedelta
 from enum import Enum
 import pytz
 from timefhuman.utils import tfhConfig, Direction
 
 
-class tfhDatelike:
+class tfhMatchable:
+    matched_text_pos: Optional[Tuple[int, int]] = None
+
+
+class tfhDatelike(tfhMatchable):
     """
     A result is a single object that can be converted to a datetime, date, or time.
     
@@ -89,7 +93,7 @@ class tfhList(tfhCollection):
         return f"tfhList({self.items})"
 
 
-class tfhTimedelta:
+class tfhTimedelta(tfhMatchable):
     def __init__(self, days: int = 0, seconds: int = 0, unit: Optional[str] = None):
         self.days = days
         self.seconds = seconds
@@ -249,7 +253,7 @@ class tfhDatetime(tfhDatelike):
         return f"tfhDatetime({self.date}, {self.time})"
     
 
-class tfhAmbiguous:
+class tfhAmbiguous(tfhMatchable):
     """Can represent an hour, a day, month, or year."""
     
     def __init__(self, value: int):
@@ -267,7 +271,7 @@ class tfhAmbiguous:
         return f"tfhAmbiguous({self.value})"
 
 
-class tfhUnknown:
+class tfhUnknown(tfhMatchable):
     def __init__(self, value: str):
         self.value = value
         

--- a/timefhuman/utils.py
+++ b/timefhuman/utils.py
@@ -18,12 +18,9 @@ Direction = Enum('Direction', ['previous', 'next', 'nearest'])
 class tfhConfig:
     direction: Direction = Direction.next
     infer_datetimes: bool = True
-    now: datetime = datetime.now()
-    
-    # NOTE: Right now, unmatched text is returned character by character.
-    # And it doesn't retain whitespace. So it's generally useless, except
-    # for debugging.
-    return_unmatched: bool = False
+    now: datetime = datetime.now()    
+    return_matched_text: bool = False
+    return_single_object: bool = True
 
 
 def generate_timezone_mapping():


### PR DESCRIPTION
Return both the matched text as well as the datetime. Allows you to correspond each parsed date-like object to the original text