### PR TITLE
[grammar] Do not match subsets of words

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -171,7 +171,6 @@ def test_custom_config(now, config, test_input, expected):
     ('There are 3 ways to do it', []),  # '3' should remain ambiguous and then be ignored
     ('salmon', []),  # no date or time (contains 'mon' but suffixes another word)
     ('9 amtrak tickets', []),  # no date or time (contains '9 am')
-    # TODO: get matched characters gh#9
 ])
-def test_with_random_text(now, test_input, expected):
+def test_matched_text(now, test_input, expected):  # gh#9
     assert timefhuman(test_input, tfhConfig(now=now, return_matched_text=True)) == expected

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -169,8 +169,7 @@ def test_custom_config(now, config, test_input, expected):
     ('September 30, 2019.', [('September 30, 2019', datetime.datetime(2019, 9, 30, 0, 0))]), # gh#26
     ('How does 5p mon sound? Or maybe 4p tu?', [('5p mon', datetime.datetime(2018, 8, 6, 17, 0)), ('4p tu', datetime.datetime(2018, 8, 7, 16, 0))]),
     ('There are 3 ways to do it', []),  # '3' should remain ambiguous and then be ignored
-    ('salmon', []),  # no date or time (contains 'mon' but suffixes another word)
-    ('9 amtrak tickets', []),  # no date or time (contains '9 am')
+    ('salmon for 9 amtrak tickets', []),  # no date or time (contains 'mon' and '9 am')
 ])
 def test_matched_text(now, test_input, expected):  # gh#9
     assert timefhuman(test_input, tfhConfig(now=now, return_matched_text=True)) == expected

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -169,6 +169,8 @@ def test_custom_config(now, config, test_input, expected):
     ('September 30, 2019.', [('September 30, 2019', datetime.datetime(2019, 9, 30, 0, 0))]), # gh#26
     ('How does 5p mon sound? Or maybe 4p tu?', [('5p mon', datetime.datetime(2018, 8, 6, 17, 0)), ('4p tu', datetime.datetime(2018, 8, 7, 16, 0))]),
     ('There are 3 ways to do it', []),  # '3' should remain ambiguous and then be ignored
+    ('setup', []),  # no date or time (contains 'tu' but in another word)
+    ('9 amtrak', []),  # no date or time (contains 'am')
     # TODO: get matched characters gh#9
 ])
 def test_with_random_text(now, test_input, expected):

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -169,8 +169,8 @@ def test_custom_config(now, config, test_input, expected):
     ('September 30, 2019.', [('September 30, 2019', datetime.datetime(2019, 9, 30, 0, 0))]), # gh#26
     ('How does 5p mon sound? Or maybe 4p tu?', [('5p mon', datetime.datetime(2018, 8, 6, 17, 0)), ('4p tu', datetime.datetime(2018, 8, 7, 16, 0))]),
     ('There are 3 ways to do it', []),  # '3' should remain ambiguous and then be ignored
-    ('setup', []),  # no date or time (contains 'tu' but in another word)
-    ('9 amtrak', []),  # no date or time (contains 'am')
+    ('salmon', []),  # no date or time (contains 'mon' but suffixes another word)
+    ('9 amtrak tickets', []),  # no date or time (contains '9 am')
     # TODO: get matched characters gh#9
 ])
 def test_with_random_text(now, test_input, expected):

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -169,7 +169,7 @@ def test_custom_config(now, config, test_input, expected):
     ('September 30, 2019.', [('September 30, 2019', datetime.datetime(2019, 9, 30, 0, 0))]), # gh#26
     ('How does 5p mon sound? Or maybe 4p tu?', [('5p mon', datetime.datetime(2018, 8, 6, 17, 0)), ('4p tu', datetime.datetime(2018, 8, 7, 16, 0))]),
     ('There are 3 ways to do it', []),  # '3' should remain ambiguous and then be ignored
-    ('salmon for 9 amtrak tickets', []),  # no date or time (contains 'mon' and '9 am')
+    ('salmon for 9 amnesty tickets', []),  # no date or time (contains 'mon' and '9 am')
 ])
 def test_matched_text(now, test_input, expected):  # gh#9
     assert timefhuman(test_input, tfhConfig(now=now, return_matched_text=True)) == expected

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -139,7 +139,7 @@ def test_default(now, test_input, expected):
     ('last Wednesday of December', datetime.date(2018, 12, 26)), # gh#4
     
     # support for vernacular datetimes
-    ('afternoon', datetime.time(hour=12, minute=0)),
+    ('afternoon', datetime.time(hour=15, minute=0)),
     ('morning', datetime.time(hour=6, minute=0)),
     ('evening', datetime.time(hour=18, minute=0)),
     ('night', datetime.time(hour=20, minute=0)),

--- a/timefhuman/grammar.lark
+++ b/timefhuman/grammar.lark
@@ -7,40 +7,40 @@
 // ----------------------
 
 // Month names as a regex token, case-insensitive
-MONTHNAME: /(?i)(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)/
+MONTHNAME: /(?i)(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)(?![a-z])/
 
 // For weekdays, also as a single regex token, case-insensitive
-WEEKDAY: /(?i)(monday|mon|tuesday|tues|tue|tu|wednesday|wed|thursday|thurs|thur|thu|friday|fri|saturday|sat|sunday|sun)/
+WEEKDAY: /(?i)(monday|mon|tuesday|tues|tue|tu|wednesday|wed|thursday|thurs|thur|thu|friday|fri|saturday|sat|sunday|sun)(?![a-z])/
 
 // Meridiem token (am/pm, with optional dots)
-MERIDIEM: /(?i)([ap](\.?m\.?)?)/
+MERIDIEM: /(?i)([ap](\.?m\.?)?)(?![a-z])/
 
 // Datename token specifies only day
-DATENAME: /(?i)(today|tomorrow|tmw|yesterday)/
+DATENAME: /(?i)(today|tomorrow|tmw|yesterday)(?![a-z])/
 
 // Timename token specifies only time
-TIMENAME: /(?i)(noon|midday|midnight|morning|afternoon|evening|night)/
+TIMENAME: /(?i)(noon|midday|midnight|morning|afternoon|evening|night)(?![a-z])/
 
 // Datetimename token specifies date and time
-DATETIMENAME: /(?i)(tonight)/
+DATETIMENAME: /(?i)(tonight)(?![a-z])/
 
 // Duration unit (minutes, hours, days, etc.)
-DURATION_UNIT: /(?i)(seconds|second|secs|sec|minutes|mins|min|hours|hour|hrs|hr|h|days|day|weeks|week|wks|wk|months|month|mos|years|year)/
+DURATION_UNIT: /(?i)(seconds|second|secs|sec|minutes|mins|min|hours|hour|hrs|hr|h|days|day|weeks|week|wks|wk|months|month|mos|years|year)(?![a-z])/
 DURATION_UNIT_LETTER: /(?i)(s|m|h|d|w|mo|y)(?![a-z])/
 
 // Duration number (digits like "1", or words like "an", "a", "one", "two", etc.)
-DURATION_NUMBER: /(?i)(an|a|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety)/
+DURATION_NUMBER: /(?i)(an|a|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety)(?![a-z])/
 
 // Day suffix (th, rd, st, nd)
-DAY_SUFFIX: /(?i)(th|rd|st|nd)/
+DAY_SUFFIX: /(?i)(th|rd|st|nd)(?![a-z])/
 
 FLOAT_NUMBER: /((\d+\.\d*|\.\d+)(e[-+]?\d+)?|\d+(e[-+]?\d+))/i  // from lark
 
-TIMEZONE: /(?i)((TIMEZONE_MAPPING))/
+TIMEZONE: /(?i)((TIMEZONE_MAPPING))(?![a-z])/
 
-MODIFIER: /(?i)(next|last|this|upcoming|previous|past)/
+MODIFIER: /(?i)(next|last|this|upcoming|previous|past)(?![a-z])/
 
-POSITION: /(?i)(first|second|third|fourth|last)/
+POSITION: /(?i)(first|second|third|fourth|last)(?![a-z])/
 
 // ----------------------
 // PARSER RULES

--- a/timefhuman/grammar.lark
+++ b/timefhuman/grammar.lark
@@ -7,40 +7,40 @@
 // ----------------------
 
 // Month names as a regex token, case-insensitive
-MONTHNAME: /(?i)(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)(?![a-z])/
+MONTHNAME: /(?i)(?<![a-z])(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)(?![a-z])/
 
 // For weekdays, also as a single regex token, case-insensitive
-WEEKDAY: /(?i)(monday|mon|tuesday|tues|tue|tu|wednesday|wed|thursday|thurs|thur|thu|friday|fri|saturday|sat|sunday|sun)(?![a-z])/
+WEEKDAY: /(?i)(?<![a-z])(monday|mon|tuesday|tues|tue|tu|wednesday|wed|thursday|thurs|thur|thu|friday|fri|saturday|sat|sunday|sun)(?![a-z])/
 
 // Meridiem token (am/pm, with optional dots)
-MERIDIEM: /(?i)([ap](\.?m\.?)?)(?![a-z])/
+MERIDIEM: /(?i)(?<![a-z])([ap](\.?m\.?)?)(?![a-z])/
 
 // Datename token specifies only day
-DATENAME: /(?i)(today|tomorrow|tmw|yesterday)(?![a-z])/
+DATENAME: /(?i)(?<![a-z])(today|tomorrow|tmw|yesterday)(?![a-z])/
 
 // Timename token specifies only time
-TIMENAME: /(?i)(noon|midday|midnight|morning|afternoon|evening|night)(?![a-z])/
+TIMENAME: /(?i)(?<![a-z])(noon|midday|midnight|morning|afternoon|evening|night)(?![a-z])/
 
 // Datetimename token specifies date and time
-DATETIMENAME: /(?i)(tonight)(?![a-z])/
+DATETIMENAME: /(?i)(?<![a-z])(tonight)(?![a-z])/
 
 // Duration unit (minutes, hours, days, etc.)
-DURATION_UNIT: /(?i)(seconds|second|secs|sec|minutes|mins|min|hours|hour|hrs|hr|h|days|day|weeks|week|wks|wk|months|month|mos|years|year)(?![a-z])/
-DURATION_UNIT_LETTER: /(?i)(s|m|h|d|w|mo|y)(?![a-z])/
+DURATION_UNIT: /(?i)(?<![a-z])(seconds|second|secs|sec|minutes|mins|min|hours|hour|hrs|hr|h|days|day|weeks|week|wks|wk|months|month|mos|years|year)(?![a-z])/
+DURATION_UNIT_LETTER: /(?i)(?<![a-z])(s|m|h|d|w|mo|y)(?![a-z])/
 
 // Duration number (digits like "1", or words like "an", "a", "one", "two", etc.)
-DURATION_NUMBER: /(?i)(an|a|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety)(?![a-z])/
+DURATION_NUMBER: /(?i)(?<![a-z])(an|a|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety)(?![a-z])/
 
 // Day suffix (th, rd, st, nd)
-DAY_SUFFIX: /(?i)(th|rd|st|nd)(?![a-z])/
+DAY_SUFFIX: /(?i)(?<![a-z])(th|rd|st|nd)(?![a-z])/
 
 FLOAT_NUMBER: /((\d+\.\d*|\.\d+)(e[-+]?\d+)?|\d+(e[-+]?\d+))/i  // from lark
 
-TIMEZONE: /(?i)((TIMEZONE_MAPPING))(?![a-z])/
+TIMEZONE: /(?i)(?<![a-z])((TIMEZONE_MAPPING))(?![a-z])/
 
-MODIFIER: /(?i)(next|last|this|upcoming|previous|past)(?![a-z])/
+MODIFIER: /(?i)(?<![a-z])(next|last|this|upcoming|previous|past)(?![a-z])/
 
-POSITION: /(?i)(first|second|third|fourth|last)(?![a-z])/
+POSITION: /(?i)(?<![a-z])(first|second|third|fourth|last)(?![a-z])/
 
 // ----------------------
 // PARSER RULES


### PR DESCRIPTION
Was matching subsets of words, like `mon` in `salmon` or `am` in `amnesty`. Updated the regex to disallow preceding or succeeding letters.