### PR TITLE
[api] Conveniences for import

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ config = tfhConfig()
 datetime.datetime(2018, 8, 6, 12, 0)
 ```
 
-**Don't infer**: Alternatively, say you want to extract only the time from a text -- perhaps it's a festival's schedule. You can disable date inference by setting `infer_datetimes=False`. Instead of always returning a datetime, timefhuman will be able to return time-like objects for only explicitly-written information.
+**Use explicit information only**: Say you only want to extract *dates* OR *times*. You don't want the library to infer information. You can disable most inference by setting `infer_datetimes=False`. Instead of always returning a datetime, timefhuman will be able to return date or time objects, depending on what's provided.
 
 ```python
 >>> config = tfhConfig(infer_datetimes=False)
@@ -129,6 +129,19 @@ datetime.time(15, 0)
 
 >>> timefhuman('12/18/18', config=config)
 datetime.date(2018, 12, 18)
+```
+
+**Past datetimes**: By default, datetimes are assumed to occur in the future, so if "3pm" today has already passed, the returned datetime will be for *tomorrow*. However, if datetimes are assumed to have occurred in the past (e.g., from an old letter, talking about past events), you can configure the direction.
+
+```python
+>>> from timefhuman import Direction
+>>> config = tfhConfig(direction=Direction.previous)
+
+>>> timefhuman('3PM')  # the default
+datetime.datetime(2018, 8, 5, 15, 0)
+
+>>> timefhuman('3PM', config=config)  # changing direction
+datetime.datetime(2018, 8, 4, 15, 0)
 ```
 
 Here is the full set of supported configuration options:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -166,8 +166,13 @@ def test_custom_config(now, config, test_input, expected):
 
 
 @pytest.mark.parametrize("test_input, expected", [
-    ('September 30, 2019.', [('September 30, 2019', datetime.datetime(2019, 9, 30, 0, 0))]), # gh#26
-    ('How does 5p mon sound? Or maybe 4p tu?', [('5p mon', datetime.datetime(2018, 8, 6, 17, 0)), ('4p tu', datetime.datetime(2018, 8, 7, 16, 0))]),
+    ('September 30, 2019.', [
+        ('September 30, 2019', (0, 18), datetime.datetime(2019, 9, 30, 0, 0))
+    ]), # gh#26
+    ('How does 5p mon sound? Or maybe 4p tu?', [
+        ('5p mon', (9, 15), datetime.datetime(2018, 8, 6, 17, 0)),
+        ('4p tu', (32, 37), datetime.datetime(2018, 8, 7, 16, 0))
+    ]),
     ('There are 3 ways to do it', []),  # '3' should remain ambiguous and then be ignored
     ('salmon for 9 amnesty tickets', []),  # no date or time (contains 'mon' and '9 am')
 ])

--- a/timefhuman/__init__.py
+++ b/timefhuman/__init__.py
@@ -1,1 +1,1 @@
-from .main import timefhuman
+from .main import timefhuman, tfhConfig, Direction

--- a/timefhuman/main.py
+++ b/timefhuman/main.py
@@ -41,8 +41,9 @@ def timefhuman(string, config: tfhConfig = tfhConfig(), raw=None):
     datetimes = [renderer.to_object(config) for renderer in renderers]
     
     if config.return_matched_text:
-        matched_texts = [string[renderer.matched_text_pos[0]:renderer.matched_text_pos[1]] for renderer in renderers]
-        return list(zip(matched_texts, datetimes))
+        positions = [(renderer.matched_text_pos[0], renderer.matched_text_pos[1]) for renderer in renderers]
+        matched_texts = [string[start: end] for start, end in positions]
+        return list(zip(matched_texts, positions, datetimes))
     
     if config.return_single_object and len(datetimes) == 1:
         return datetimes[0]


### PR DESCRIPTION
- exposed `Direction`, `tfhConfig` to `from timefhuman import *`, like the README implies
- returned string positions for the matched text, to distinguish between identical matched texts