### PR TITLE
[parser] Fix colon parsing

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -145,6 +145,8 @@ def test_default(now, test_input, expected):
     ('night', datetime.time(hour=20, minute=0)),
     ('today night', datetime.datetime(2018, 8, 4, 20, 0)),
     ('tonight', datetime.datetime(2018, 8, 4, 20, 0)), # gh#30
+    
+    ('e 6:50PM', datetime.time(hour=18, minute=50)), # gh#51
 ])
 def test_no_inference(now, test_input, expected):
     """Return exactly the date or time, without inferring the other."""

--- a/timefhuman/grammar.lark
+++ b/timefhuman/grammar.lark
@@ -42,6 +42,8 @@ MODIFIER: /(?i)(?<![a-z])(next|last|this|upcoming|previous|past)(?![a-z])/
 
 POSITION: /(?i)(?<![a-z])(first|second|third|fourth|last)(?![a-z])/
 
+COLON: ":"
+
 // ----------------------
 // PARSER RULES
 // ----------------------
@@ -94,7 +96,7 @@ date: weekday? month "/" day "/" year
 // classified as an ambiguous token (in case it's a month, day, year, etc.)
 // However, that means to support single-integer (e.g., hour) times, we need
 // to manually add them to the `datetime` rule above.
-time: hour ":" minute (":" second ("." millisecond)?)? meridiem? timezone?
+time: hour COLON minute (COLON second ("." millisecond)?)? meridiem? timezone?
     | hour ("o'clock")? meridiem timezone?
     | timename timezone?
 
@@ -131,4 +133,4 @@ position: POSITION
 
 ambiguous: INT
 
-unknown: /\S/
+unknown: /[^\s:]/


### PR DESCRIPTION
Parsing the colon as unk and the preceding number (the hour) as ambiguous. To fix this, give the colon terminal higher priority than unk.