### PR TITLE
[tzinfo] Handle timezones when times aren't specified

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -211,6 +211,11 @@ def test_timezone(now):  # gh#52
     
     # 1. When a timezone is specified in the original text, honor this first.
     assert timefhuman('Wed EST', tfhConfig(now=now_PST)) == datetime.datetime(2018, 8, 8, 0, 0, tzinfo=pytz.timezone('US/Michigan'))
+    assert timefhuman('Wed 5p EST', tfhConfig(now=now_PST)) == datetime.datetime(2018, 8, 8, 17, 0, tzinfo=pytz.timezone('US/Michigan'))
+    assert timefhuman('5p EST', tfhConfig(now=now_PST)) == datetime.datetime(2018, 8, 4, 17, 0, tzinfo=pytz.timezone('US/Michigan'))
+    assert timefhuman('5p EST', tfhConfig(now=now_PST, direction=Direction.previous)) == datetime.datetime(2018, 8, 3, 17, 0, tzinfo=pytz.timezone('US/Michigan'))
+    assert timefhuman('9a EST', tfhConfig(now=now_PST, direction=Direction.next)) == datetime.datetime(2018, 8, 5, 9, 0, tzinfo=pytz.timezone('US/Michigan'))
+    assert timefhuman('9a EST', tfhConfig(now=now_PST, infer_datetimes=False)) == datetime.time(9, 0, tzinfo=pytz.timezone('US/Michigan'))
     # 2. Otherwise, if a timezone is specified in `now`, use this.
     assert timefhuman('Wed', tfhConfig(now=now_PST)) == datetime.datetime(2018, 8, 8, 0, 0, tzinfo=pytz.timezone('US/Pacific'))
     # 3. If no timezone is specified, do not attach one

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -208,11 +208,10 @@ def test_timezone(now):  # gh#52
     2. Otherwise, if a timezone is specified in `now`, use this.
     """
     now_PST = now.replace(tzinfo=pytz.timezone('US/Pacific'))
-    now_EST = now.replace(tzinfo=pytz.timezone('US/Michigan'))
     
     # 1. When a timezone is specified in the original text, honor this first.
-    assert timefhuman('Wed 5p EST', tfhConfig(now=now_PST)) == now_EST
+    assert timefhuman('Wed EST', tfhConfig(now=now_PST)) == datetime.datetime(2018, 8, 8, 0, 0, tzinfo=pytz.timezone('US/Michigan'))
     # 2. Otherwise, if a timezone is specified in `now`, use this.
-    assert timefhuman('Wed', tfhConfig(now=now_PST)) == now_PST
+    assert timefhuman('Wed', tfhConfig(now=now_PST)) == datetime.datetime(2018, 8, 8, 0, 0, tzinfo=pytz.timezone('US/Pacific'))
     # 3. If no timezone is specified, do not attach one
-    assert timefhuman('Wed', tfhConfig(now=now)) == now
+    assert timefhuman('Wed', tfhConfig(now=now)) == datetime.datetime(2018, 8, 8, 0, 0)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -199,3 +199,20 @@ def test_now_changes(now): # gh#53
     # 'now' should change each time we call the function
     config = tfhConfig()
     assert timefhuman('5p', now=True) != timefhuman('5p', now=True)
+
+
+def test_timezone(now):  # gh#52
+    """
+    Support timezones specifications without a specific time.
+    1. When a timezone is specified in the original text, honor this first.
+    2. Otherwise, if a timezone is specified in `now`, use this.
+    """
+    now_PST = now.replace(tzinfo=pytz.timezone('US/Pacific'))
+    now_EST = now.replace(tzinfo=pytz.timezone('US/Michigan'))
+    
+    # 1. When a timezone is specified in the original text, honor this first.
+    assert timefhuman('Wed 5p EST', tfhConfig(now=now_PST)) == now_EST
+    # 2. Otherwise, if a timezone is specified in `now`, use this.
+    assert timefhuman('Wed', tfhConfig(now=now_PST)) == now_PST
+    # 3. If no timezone is specified, do not attach one
+    assert timefhuman('Wed', tfhConfig(now=now)) == now

--- a/timefhuman/grammar.lark
+++ b/timefhuman/grammar.lark
@@ -62,14 +62,14 @@ single: datetime
 
 // Only add houronly to specific formats that immediately
 // indicate this is an hour-only time.
-datetime: date ("at" (time | houronly))?
-        | date (time | houronly)
-        | date "T" time  // ISO 8601
-        | (time | houronly) date
-        | (time | houronly) "on" date
-        | date
-        | time
-        | datetimename
+datetime: date ("at" (time | houronly))? timezone?
+        | date (time | houronly) timezone?
+        | date "T" time timezone?  // ISO 8601
+        | (time | houronly) date timezone?
+        | (time | houronly) "on" date timezone?
+        | date timezone?
+        | time timezone?
+        | datetimename timezone?
 
 // NOTE: process month modifiers here since the modifier affects the year, which
 // won't be processed until the date rule. If additional modifiers are added,
@@ -95,8 +95,8 @@ date: weekday? month "/" day "/" year
 // However, that means to support single-integer (e.g., hour) times, we need
 // to manually add them to the `datetime` rule above.
 time: hour ":" minute (":" second ("." millisecond)?)? meridiem? timezone?
-    | hour ("o'clock")? meridiem timezone?
-    | timename timezone?
+    | hour ("o'clock" meridiem|"o'clock"|meridiem)
+    | timename
 
 duration: ("in"|"for")? duration_part (("and"|",")? duration_part)* ("ago")?
 duration_part: duration_number (duration_unit | duration_unit_letter)

--- a/timefhuman/main.py
+++ b/timefhuman/main.py
@@ -203,7 +203,7 @@ class tfhTransformer(Transformer):
         data = nodes_to_dict(children)
         if 'datetime' in data:
             return data['datetime']
-        return tfhDatetime(date=data.get('date'), time=data.get('time'))
+        return tfhDatetime(date=data.get('date'), time=data.get('time'), tz=data.get('timezone'))
     
     def date(self, children):
         data = nodes_to_dict(children)
@@ -320,8 +320,7 @@ class tfhTransformer(Transformer):
             minute=int(data.get("minute", 0)),
             second=int(data.get("second", 0)),
             millisecond=int(data.get("millisecond", 0)),
-            meridiem=data.get("meridiem", None),
-            tz=data.get("timezone", None),
+            meridiem=data.get("meridiem", None)
         )}
     
     def meridiem(self, children):


### PR DESCRIPTION
Propagate timezones even when only dates are specified. To do this, moved timezone handling to the `datetime` rule rather than the `time` rule.

Considers:
1. Timezone specified in the input. This takes priority.
2. Timezone specified in `config.now`. This takes second priority.
3. If no timezone is specified in either, no timezone is assigned to the returned object.