### PR TITLE
[config] Remove `return_single_object` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,64 +30,64 @@ The text can contain not only datetimes but also ranges of datetimes or lists of
 
 ```python
 >>> timefhuman('3p-4p')  # time range
-(datetime.datetime(2018, 7, 17, 15, 0), datetime.datetime(2018, 7, 17, 16, 0))
+[(datetime.datetime(2018, 7, 17, 15, 0), datetime.datetime(2018, 7, 17, 16, 0))]
 
 >>> timefhuman('7/17 4PM to 7/17 5PM')  # range of datetimes
-(datetime.datetime(2018, 7, 17, 16, 0), datetime.datetime(2018, 7, 17, 17, 0))
+[(datetime.datetime(2018, 7, 17, 16, 0), datetime.datetime(2018, 7, 17, 17, 0))]
 
 >>> timefhuman('Monday 3 pm or Tu noon')  # list of datetimes
-[datetime.datetime(2018, 8, 6, 15, 0), datetime.datetime(2018, 8, 7, 12, 0)]
+[[datetime.datetime(2018, 8, 6, 15, 0), datetime.datetime(2018, 8, 7, 12, 0)]]
 
 >>> timefhuman('7/17 4-5 or 5-6 PM')  # list of ranges of datetimes!
-[(datetime.datetime(2018, 7, 17, 16, 0), datetime.datetime(2018, 7, 17, 17, 0)),
- (datetime.datetime(2018, 7, 17, 17, 0), datetime.datetime(2018, 7, 17, 18, 0))]
+[[(datetime.datetime(2018, 7, 17, 16, 0), datetime.datetime(2018, 7, 17, 17, 0)),
+  (datetime.datetime(2018, 7, 17, 17, 0), datetime.datetime(2018, 7, 17, 18, 0))]]
 ```
 
 Durations are also supported.
 
 ```python
 >>> timefhuman('30 minutes')  # duration
-datetime.datetime(2018, 8, 4, 14, 30)
+[datetime.datetime(2018, 8, 4, 14, 30)]
 
 >>> timefhuman('30-40 mins')  # range of durations
-(datetime.datetime(2018, 8, 4, 14, 30), datetime.datetime(2018, 8, 4, 14, 40))
+[(datetime.datetime(2018, 8, 4, 14, 30), datetime.datetime(2018, 8, 4, 14, 40))]
 
 >>> timefhuman('30 or 40m')  # list of durations
-[datetime.datetime(2018, 8, 4, 14, 30), datetime.datetime(2018, 8, 4, 14, 40)]
+[[datetime.datetime(2018, 8, 4, 14, 30), datetime.datetime(2018, 8, 4, 14, 40)]]
 ```
 
 When possible, timefhuman will infer any missing information, using context from other datetimes.
 
 ```python
 >>> timefhuman('3-4p')  # infer "PM" for "3"
-(datetime.datetime(2018, 7, 17, 15, 0), datetime.datetime(2018, 7, 17, 16, 0))
+[(datetime.datetime(2018, 7, 17, 15, 0), datetime.datetime(2018, 7, 17, 16, 0))]
 
 >>> timefhuman('7/17 4 or 5 PM')  # infer "PM" for "4" and infer "7/17" for "5 PM"
-[datetime.datetime(2018, 7, 17, 16, 0), datetime.datetime(2018, 7, 17, 17, 0)]
+[[datetime.datetime(2018, 7, 17, 16, 0), datetime.datetime(2018, 7, 17, 17, 0)]]
 
 >>> timefhuman('7/17, 7/18, 7/19 at 9')  # infer "9a" for "7/17", "7/18"
-[datetime.datetime(2018, 7, 17, 9, 0), datetime.datetime(2018, 7, 18, 9, 0),
- datetime.datetime(2018, 7, 19, 9, 0)]
+[[datetime.datetime(2018, 7, 17, 9, 0), datetime.datetime(2018, 7, 18, 9, 0),
+  datetime.datetime(2018, 7, 19, 9, 0)]]
 
 >>> timefhuman('3p -4p PDT')  # infer timezone "PDT" for "3p"
-(datetime.datetime(2018, 8, 4, 15, 0, tzinfo=pytz.timezone('US/Pacific')),
- datetime.datetime(2018, 8, 4, 16, 0, tzinfo=pytz.timezone('US/Pacific')))
+[(datetime.datetime(2018, 8, 4, 15, 0, tzinfo=pytz.timezone('US/Pacific')),
+  datetime.datetime(2018, 8, 4, 16, 0, tzinfo=pytz.timezone('US/Pacific')))]
 ```
 
 You can also use natural language descriptions of dates and times.
 
 ```python
 >>> timefhuman('next Monday')
-datetime.datetime(2018, 8, 6, 0, 0)
+[datetime.datetime(2018, 8, 6, 0, 0)]
 
 >>> timefhuman('next next Monday')
-datetime.datetime(2018, 8, 13, 0, 0)
+[datetime.datetime(2018, 8, 13, 0, 0)]
 
 >>> timefhuman('last Wednesday of December')
-datetime.datetime(2018, 12, 26, 0, 0)
+[datetime.datetime(2018, 12, 26, 0, 0)]
 
 >>> timefhuman('afternoon')
-datetime.datetime(2018, 8, 4, 15, 0)
+[datetime.datetime(2018, 8, 4, 15, 0)]
 ```
 
 See more examples in [`tests/test_e2e.py`](tests/test_e2e.py).
@@ -116,7 +116,7 @@ config = tfhConfig()
 >>> config = tfhConfig(now=datetime.datetime(2018, 8, 4, 0, 0))
 
 >>> timefhuman('upcoming Monday noon', config=config)
-datetime.datetime(2018, 8, 6, 12, 0)
+[datetime.datetime(2018, 8, 6, 12, 0)]
 ```
 
 You can also set a default timezone, by again using the config's `now`.
@@ -126,10 +126,10 @@ You can also set a default timezone, by again using the config's `now`.
 ...     now=datetime.datetime(2018, 8, 4), tzinfo=pytz.timezone('US/Pacific'))
 
 >>> timefhuman('Wed', config=config)
-datetime.datetime(2018, 8, 8, 0, 0, tzinfo=pytz.timezone('US/Pacific'))
+[datetime.datetime(2018, 8, 8, 0, 0, tzinfo=pytz.timezone('US/Pacific'))]
 
 >>> timefhuman('Wed EST', config=config)  # EST timezone in the input takes precedence
-datetime.datetime(2018, 8, 8, 0, 0, tzinfo=pytz.timezone('US/Michigan'))
+[datetime.datetime(2018, 8, 8, 0, 0, tzinfo=pytz.timezone('US/Michigan'))]
 ```
 
 **Use explicit information only**: Say you only want to extract *dates* OR *times* OR *timedeltas*. You don't want the library to infer information. You can disable most inference by setting `infer_datetimes=False`. Instead of always returning a datetime, timefhuman will be able to return date, time, or timedelta objects depending on what's provided.
@@ -138,13 +138,13 @@ datetime.datetime(2018, 8, 8, 0, 0, tzinfo=pytz.timezone('US/Michigan'))
 >>> config = tfhConfig(infer_datetimes=False)
 
 >>> timefhuman('3 PM', config=config)  # time
-datetime.time(15, 0)
+[datetime.time(15, 0)]
 
 >>> timefhuman('12/18/18', config=config)  # date
-datetime.date(2018, 12, 18)
+[datetime.date(2018, 12, 18)]
 
 >>> timefhuman('30 minutes')  # duration
-datetime.timedelta(seconds=1800)
+[datetime.timedelta(seconds=1800)]
 ```
 
 **Past datetimes**: By default, datetimes are assumed to occur in the future, so if "3pm" today has already passed, the returned datetime will be for *tomorrow*. However, if datetimes are assumed to have occurred in the past (e.g., from an old letter, talking about past events), you can configure the direction.
@@ -154,10 +154,10 @@ datetime.timedelta(seconds=1800)
 >>> config = tfhConfig(direction=Direction.previous)
 
 >>> timefhuman('3PM')  # the default
-datetime.datetime(2018, 8, 5, 15, 0)
+[datetime.datetime(2018, 8, 5, 15, 0)]
 
 >>> timefhuman('3PM', config=config)  # changing direction
-datetime.datetime(2018, 8, 4, 15, 0)
+[datetime.datetime(2018, 8, 4, 15, 0)]
 ```
 
 Here is the full set of supported configuration options:
@@ -168,18 +168,16 @@ class tfhConfig:
     # Default to the next valid datetime or the previous one
     direction: Direction = Direction.next
     
-    # Always return datetime objects. If no date, use now.date(). If no time, use midnight.
-    # If timedelta, add it to the current datetime.
+    # Always produce datetime objects. If no date, use the current date. If no time, use midnight.
+    # If timedelta, add it to the current datetime. Still allows ranges (tuples) of datetimes and
+    # lists of datetimes.
     infer_datetimes: bool = True
     
-    # The 'current' datetime, used if infer_datetimes is True. Defaults to datetime.now().
+    # The 'current' datetime, used if infer_datetimes is True
     now: datetime | None = None
     
     # Return the matched text from the input string
     return_matched_text: bool = False
-    
-    # Return a single object instead of a list when there's only one match
-    return_single_object: bool = False
 ```
 
 ## Development

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -12,72 +12,72 @@ def now():
 
 @pytest.mark.parametrize("test_input, expected", [
     # time only
-    ('5p', datetime.datetime(2018, 8, 4, 17, 0)),
-    ('3p EST', datetime.datetime(2018, 8, 4, 15, 0, tzinfo=pytz.timezone('US/Michigan'))),  # fixes gh#6
+    ('5p', [datetime.datetime(2018, 8, 4, 17, 0)]),
+    ('3p EST', [datetime.datetime(2018, 8, 4, 15, 0, tzinfo=pytz.timezone('US/Michigan'))]),  # fixes gh#6
     
     # date only
-    ('July 2019', datetime.datetime(2019, 7, 1, 0, 0)),
-    ('7-17-18', datetime.datetime(2018, 7, 17, 0, 0)),
-    ('2018-7-17', datetime.datetime(2018, 7, 17, 0, 0)),  # support YMD
-    ('7/2018', datetime.datetime(2018, 7, 1, 0, 0)),
+    ('July 2019', [datetime.datetime(2019, 7, 1, 0, 0)]),
+    ('7-17-18', [datetime.datetime(2018, 7, 17, 0, 0)]),
+    ('2018-7-17', [datetime.datetime(2018, 7, 17, 0, 0)]),  # support YMD
+    ('7/2018', [datetime.datetime(2018, 7, 1, 0, 0)]),
     
     # datetimes
-    ('July 17, 2018 at 3p.m.', datetime.datetime(2018, 7, 17, 15, 0)),
-    ('July 17, 2018 3 p.m.', datetime.datetime(2018, 7, 17, 15, 0)),
-    ('3PM on July 17', datetime.datetime(2018, 7, 17, 15, 0)),
-    ('July 17 at 3', datetime.datetime(2018, 7, 17, 3, 0)),
-    ('7/17/18 3:00 p.m.', datetime.datetime(2018, 7, 17, 15, 0)),
-    ('3 p.m. today', datetime.datetime(2018, 8, 4, 15, 0)),
-    ('Tomorrow 3p', datetime.datetime(2018, 8, 5, 15, 0)), # gh#24
-    ('3p tomorrow', datetime.datetime(2018, 8, 5, 15, 0)),
-    ('July 3rd', datetime.datetime(2018, 7, 3, 0, 0)),
+    ('July 17, 2018 at 3p.m.', [datetime.datetime(2018, 7, 17, 15, 0)]),
+    ('July 17, 2018 3 p.m.', [datetime.datetime(2018, 7, 17, 15, 0)]),
+    ('3PM on July 17', [datetime.datetime(2018, 7, 17, 15, 0)]),
+    ('July 17 at 3', [datetime.datetime(2018, 7, 17, 3, 0)]),
+    ('7/17/18 3:00 p.m.', [datetime.datetime(2018, 7, 17, 15, 0)]),
+    ('3 p.m. today', [datetime.datetime(2018, 8, 4, 15, 0)]),
+    ('Tomorrow 3p', [datetime.datetime(2018, 8, 5, 15, 0)]), # gh#24
+    ('3p tomorrow', [datetime.datetime(2018, 8, 5, 15, 0)]),
+    ('July 3rd', [datetime.datetime(2018, 7, 3, 0, 0)]),
     
     # date-only ranges
-    ('7/17-7/18', (datetime.datetime(2018, 7, 17), datetime.datetime(2018, 7, 18))),
-    ('July 17-18', (datetime.datetime(2018, 7, 17), datetime.datetime(2018, 7, 18))), # distribute month
+    ('7/17-7/18', [(datetime.datetime(2018, 7, 17), datetime.datetime(2018, 7, 18))]),
+    ('July 17-18', [(datetime.datetime(2018, 7, 17), datetime.datetime(2018, 7, 18))]), # distribute month
     
     # time-only ranges
-    ('3p -4p', (datetime.datetime(2018, 8, 4, 15, 0), datetime.datetime(2018, 8, 4, 16, 0))),
-    ('3p -4p PDT', (datetime.datetime(2018, 8, 4, 15, 0, tzinfo=pytz.timezone('US/Pacific')), datetime.datetime(2018, 8, 4, 16, 0, tzinfo=pytz.timezone('US/Pacific')))),
-    ('6:00 pm - 12:00 am', (datetime.datetime(2018, 8, 4, 18, 0), datetime.datetime(2018, 8, 5, 0, 0))), # gh#8
-    ('8/4 6:00 pm - 8/4 12:00 am', (datetime.datetime(2018, 8, 4, 18, 0), datetime.datetime(2018, 8, 4, 0, 0))), # force date, do not infer
+    ('3p -4p', [(datetime.datetime(2018, 8, 4, 15, 0), datetime.datetime(2018, 8, 4, 16, 0))]),
+    ('3p -4p PDT', [(datetime.datetime(2018, 8, 4, 15, 0, tzinfo=pytz.timezone('US/Pacific')), datetime.datetime(2018, 8, 4, 16, 0, tzinfo=pytz.timezone('US/Pacific')))]),
+    ('6:00 pm - 12:00 am', [(datetime.datetime(2018, 8, 4, 18, 0), datetime.datetime(2018, 8, 5, 0, 0))]), # gh#8
+    ('8/4 6:00 pm - 8/4 12:00 am', [(datetime.datetime(2018, 8, 4, 18, 0), datetime.datetime(2018, 8, 4, 0, 0))]), # force date, do not infer
     
     # date and time ranges
-    ('7/17 3 pm- 7/19 2 pm', (datetime.datetime(2018, 7, 17, 15, 0), datetime.datetime(2018, 7, 19, 14, 0))),
-    ('Jun 28 5:00 PM - Aug 02 7:00 PM', (datetime.datetime(2018, 6, 28, 17, 0), datetime.datetime(2018, 8, 2, 19, 0))),
-    ('Jun 28 2019 5:00 PM - Aug 02 2019 7:00 PM', (datetime.datetime(2019, 6, 28, 17, 0), datetime.datetime(2019, 8, 2, 19, 0))),
-    ('6/28 5:00 PM - 8/02 7:00 PM', (datetime.datetime(2018, 6, 28, 17, 0), datetime.datetime(2018, 8, 2, 19, 0))),
-    ('6/28/2019 5:00 PM - 8/02/2019 7:00 PM', (datetime.datetime(2019, 6, 28, 17, 0), datetime.datetime(2019, 8, 2, 19, 0))),
+    ('7/17 3 pm- 7/19 2 pm', [(datetime.datetime(2018, 7, 17, 15, 0), datetime.datetime(2018, 7, 19, 14, 0))]),
+    ('Jun 28 5:00 PM - Aug 02 7:00 PM', [(datetime.datetime(2018, 6, 28, 17, 0), datetime.datetime(2018, 8, 2, 19, 0))]),
+    ('Jun 28 2019 5:00 PM - Aug 02 2019 7:00 PM', [(datetime.datetime(2019, 6, 28, 17, 0), datetime.datetime(2019, 8, 2, 19, 0))]),
+    ('6/28 5:00 PM - 8/02 7:00 PM', [(datetime.datetime(2018, 6, 28, 17, 0), datetime.datetime(2018, 8, 2, 19, 0))]),
+    ('6/28/2019 5:00 PM - 8/02/2019 7:00 PM', [(datetime.datetime(2019, 6, 28, 17, 0), datetime.datetime(2019, 8, 2, 19, 0))]),
     
     # choices
-    ('July 4th or 5th at 3PM', [datetime.datetime(2018, 7, 4, 15, 0), datetime.datetime(2018, 7, 5, 15, 0)]), # distribute month and time
-    ('tomorrow noon,Wed 3 p.m.,Fri 11 AM', [datetime.datetime(2018, 8, 5, 12, 0), datetime.datetime(2018, 8, 8, 15, 0), datetime.datetime(2018, 8, 10, 11, 0)]), # distribute meridiem
+    ('July 4th or 5th at 3PM', [[datetime.datetime(2018, 7, 4, 15, 0), datetime.datetime(2018, 7, 5, 15, 0)]]), # distribute month and time
+    ('tomorrow noon,Wed 3 p.m.,Fri 11 AM', [[datetime.datetime(2018, 8, 5, 12, 0), datetime.datetime(2018, 8, 8, 15, 0), datetime.datetime(2018, 8, 10, 11, 0)]]), # distribute meridiem
     # ('2, 3, or 4p tmw', [datetime.datetime(2018, 8, 4, 2, 0), datetime.datetime(2018, 8, 4, 3, 0), datetime.datetime(2018, 8, 4, 4, 0)]), # multiple ambiguous tokens #TODO (check month?)
     
     # choices of ranges
-    ('7/17 4-5 PM or 5-6 PM today', [
+    ('7/17 4-5 PM or 5-6 PM today', [[
         (datetime.datetime(2018, 7, 17, 16, 0), datetime.datetime(2018, 7, 17, 17, 0)),
         (datetime.datetime(2018, 8, 4, 17, 0), datetime.datetime(2018, 8, 4, 18, 0))
-    ]),
+    ]]),
     
     # timedeltas converted properly
-    ('30 minutes', datetime.datetime(2018, 8, 4, 14, 30)),
-    ('30-40 mins', (datetime.datetime(2018, 8, 4, 14, 30), datetime.datetime(2018, 8, 4, 14, 40))),
-    ('1 or 2 days', [datetime.datetime(2018, 8, 5, 14, 0), datetime.datetime(2018, 8, 6, 14, 0)]),
+    ('30 minutes', [datetime.datetime(2018, 8, 4, 14, 30)]),
+    ('30-40 mins', [(datetime.datetime(2018, 8, 4, 14, 30), datetime.datetime(2018, 8, 4, 14, 40))]),
+    ('1 or 2 days', [[datetime.datetime(2018, 8, 5, 14, 0), datetime.datetime(2018, 8, 6, 14, 0)]]),
     
     # readme
-    ('Monday noon', datetime.datetime(2018, 8, 6, 12, 0)),
-    ('3-4p', (datetime.datetime(2018, 8, 4, 15, 0), datetime.datetime(2018, 8, 4, 16, 0))), # infer meridiem
-    ('Monday 3 pm or Tu noon', [datetime.datetime(2018, 8, 6, 15, 0), datetime.datetime(2018, 8, 7, 12, 0)]),
-    ('7/17 4 or 5 PM', [datetime.datetime(2018, 7, 17, 16, 0), datetime.datetime(2018, 7, 17, 17, 0)]), # distribute meridiem / date
-    ('7/17 4-5 or 5-6 PM', [
+    ('Monday noon', [datetime.datetime(2018, 8, 6, 12, 0)]),
+    ('3-4p', [(datetime.datetime(2018, 8, 4, 15, 0), datetime.datetime(2018, 8, 4, 16, 0))]), # infer meridiem
+    ('Monday 3 pm or Tu noon', [[datetime.datetime(2018, 8, 6, 15, 0), datetime.datetime(2018, 8, 7, 12, 0)]]),
+    ('7/17 4 or 5 PM', [[datetime.datetime(2018, 7, 17, 16, 0), datetime.datetime(2018, 7, 17, 17, 0)]]), # distribute meridiem / date
+    ('7/17 4-5 or 5-6 PM', [[
         (datetime.datetime(2018, 7, 17, 16, 0), datetime.datetime(2018, 7, 17, 17, 0)),
         (datetime.datetime(2018, 7, 17, 17, 0), datetime.datetime(2018, 7, 17, 18, 0))
-    ]),
+    ]]),
     
-    ('7/17, 7/18, 7/19 at 2', [datetime.datetime(2018, 7, 17, 2, 0), datetime.datetime(2018, 7, 18, 2, 0), datetime.datetime(2018, 7, 19, 2, 0)]), # distribute dates
-    ('2 PM on 7/17 or 7/19', [datetime.datetime(2018, 7, 17, 14, 0), datetime.datetime(2018, 7, 19, 14, 0)]), # distribute time across dates
-    ('2022-12-27T09:15:01.002', datetime.datetime(2022, 12, 27, 9, 15, 1, 2)),  # fixes gh#31
+    ('7/17, 7/18, 7/19 at 2', [[datetime.datetime(2018, 7, 17, 2, 0), datetime.datetime(2018, 7, 18, 2, 0), datetime.datetime(2018, 7, 19, 2, 0)]]), # distribute dates
+    ('2 PM on 7/17 or 7/19', [[datetime.datetime(2018, 7, 17, 14, 0), datetime.datetime(2018, 7, 19, 14, 0)]]), # distribute time across dates
+    ('2022-12-27T09:15:01.002', [datetime.datetime(2022, 12, 27, 9, 15, 1, 2)]),  # fixes gh#31
 ])
 def test_default(now, test_input, expected):
     """Default behavior should be to infer datetimes and times."""
@@ -87,40 +87,40 @@ def test_default(now, test_input, expected):
 
 @pytest.mark.parametrize("test_input, expected", [
     # time only
-    ('5p', datetime.time(hour=17, minute=0)),
-    ("3 o'clock pm", datetime.time(hour=15, minute=0)), # fixes gh#12
-    ('5p Eastern Time', datetime.time(hour=17, minute=0, tzinfo=pytz.timezone('US/Michigan'))),  # fixes gh#6
+    ('5p', [datetime.time(hour=17, minute=0)]),
+    ("3 o'clock pm", [datetime.time(hour=15, minute=0)]), # fixes gh#12
+    ('5p Eastern Time', [datetime.time(hour=17, minute=0, tzinfo=pytz.timezone('US/Michigan'))]),  # fixes gh#6
     
     # date only
-    ('July 2019', datetime.date(2019, 7, 1)),
-    ('Sunday 7/7/2019', datetime.date(2019, 7, 7)),  # fixes gh#27
+    ('July 2019', [datetime.date(2019, 7, 1)]),
+    ('Sunday 7/7/2019', [datetime.date(2019, 7, 7)]),  # fixes gh#27
     
     # date-only ranges
-    ('7/17-7/18', (datetime.date(2018, 7, 17), datetime.date(2018, 7, 18))),
-    ('July 17-18', (datetime.date(2018, 7, 17), datetime.date(2018, 7, 18))), # distribute month
+    ('7/17-7/18', [(datetime.date(2018, 7, 17), datetime.date(2018, 7, 18))]),
+    ('July 17-18', [(datetime.date(2018, 7, 17), datetime.date(2018, 7, 18))]), # distribute month
     
     # time-only ranges
-    ('3p -4p', (datetime.time(15, 0), datetime.time(16, 0))),
-    ('3-4p', (datetime.time(15, 0), datetime.time(16, 0))), # distribute meridiem
+    ('3p -4p', [(datetime.time(15, 0), datetime.time(16, 0))]),
+    ('3-4p', [(datetime.time(15, 0), datetime.time(16, 0))]), # distribute meridiem
     
     # durations
-    ('30 minutes', datetime.timedelta(minutes=30)),
-    ('30 mins', datetime.timedelta(minutes=30)),
-    ('2 hours', datetime.timedelta(hours=2)),
-    ('2 hours 30 minutes', datetime.timedelta(hours=2, minutes=30)),
-    ('2 hours and 30 minutes', datetime.timedelta(hours=2, minutes=30)), # gh#22
-    ('2h30m', datetime.timedelta(hours=2, minutes=30)),
-    ('1 day and an hour', datetime.timedelta(days=1, hours=1)),
-    ('1.5 hours', datetime.timedelta(hours=1, minutes=30)),
-    ('1.5h', datetime.timedelta(hours=1, minutes=30)),
-    ('in five minutes', datetime.timedelta(minutes=5)), # gh#25
+    ('30 minutes', [datetime.timedelta(minutes=30)]),
+    ('30 mins', [datetime.timedelta(minutes=30)]),
+    ('2 hours', [datetime.timedelta(hours=2)]),
+    ('2 hours 30 minutes', [datetime.timedelta(hours=2, minutes=30)]),
+    ('2 hours and 30 minutes', [datetime.timedelta(hours=2, minutes=30)]), # gh#22
+    ('2h30m', [datetime.timedelta(hours=2, minutes=30)]),
+    ('1 day and an hour', [datetime.timedelta(days=1, hours=1)]),
+    ('1.5 hours', [datetime.timedelta(hours=1, minutes=30)]),
+    ('1.5h', [datetime.timedelta(hours=1, minutes=30)]),
+    ('in five minutes', [datetime.timedelta(minutes=5)]), # gh#25
     ('awk', []),  # should *not become 'a week'
-    ('a wk', datetime.timedelta(days=7)),
-    ('thirty two hours', datetime.timedelta(hours=32)),
+    ('a wk', [datetime.timedelta(days=7)]),
+    ('thirty two hours', [datetime.timedelta(hours=32)]),
     
     # duration ranges and lists
-    ('30-40 mins', (datetime.timedelta(minutes=30), datetime.timedelta(minutes=40))),
-    ('1 or 2 days', [datetime.timedelta(days=1), datetime.timedelta(days=2)]),
+    ('30-40 mins', [(datetime.timedelta(minutes=30), datetime.timedelta(minutes=40))]),
+    ('1 or 2 days', [[datetime.timedelta(days=1), datetime.timedelta(days=2)]]),
 
     # TODO: support "quarter to 3"
     # TODO: support "one and a half hours"
@@ -136,22 +136,22 @@ def test_default(now, test_input, expected):
     # TODO: support 'last week of dec'
     
     # support for date and month modifiers
-    ('next Monday', datetime.date(2018, 8, 6)),
-    ('next next Monday', datetime.date(2018, 8, 13)),
-    ('last Monday', datetime.date(2018, 7, 30)),
-    ('next July', datetime.date(2019, 7, 1)),
-    ('last July', datetime.date(2017, 7, 1)),
-    ('last Wednesday of December', datetime.date(2018, 12, 26)), # gh#4
+    ('next Monday', [datetime.date(2018, 8, 6)]),
+    ('next next Monday', [datetime.date(2018, 8, 13)]),
+    ('last Monday', [datetime.date(2018, 7, 30)]),
+    ('next July', [datetime.date(2019, 7, 1)]),
+    ('last July', [datetime.date(2017, 7, 1)]),
+    ('last Wednesday of December', [datetime.date(2018, 12, 26)]), # gh#4
     
     # support for vernacular datetimes
-    ('afternoon', datetime.time(hour=15, minute=0)),
-    ('morning', datetime.time(hour=6, minute=0)),
-    ('evening', datetime.time(hour=18, minute=0)),
-    ('night', datetime.time(hour=20, minute=0)),
-    ('today night', datetime.datetime(2018, 8, 4, 20, 0)),
-    ('tonight', datetime.datetime(2018, 8, 4, 20, 0)), # gh#30
+    ('afternoon', [datetime.time(hour=15, minute=0)]),
+    ('morning', [datetime.time(hour=6, minute=0)]),
+    ('evening', [datetime.time(hour=18, minute=0)]),
+    ('night', [datetime.time(hour=20, minute=0)]),
+    ('today night', [datetime.datetime(2018, 8, 4, 20, 0)]),
+    ('tonight', [datetime.datetime(2018, 8, 4, 20, 0)]), # gh#30
     
-    ('e 6:50PM', datetime.time(hour=18, minute=50)), # gh#51
+    ('e 6:50PM', [datetime.time(hour=18, minute=50)]), # gh#51
 ])
 def test_no_inference(now, test_input, expected):
     """Return exactly the date or time, without inferring the other."""
@@ -160,12 +160,12 @@ def test_no_inference(now, test_input, expected):
 
 
 @pytest.mark.parametrize("config, test_input, expected", [
-    (tfhConfig(direction=Direction.next, infer_datetimes=False), 'mon', datetime.date(2018, 8, 6)),
-    (tfhConfig(direction=Direction.previous, infer_datetimes=False), 'mon', datetime.date(2018, 7, 30)),
+    (tfhConfig(direction=Direction.next, infer_datetimes=False), 'mon', [datetime.date(2018, 8, 6)]),
+    (tfhConfig(direction=Direction.previous, infer_datetimes=False), 'mon', [datetime.date(2018, 7, 30)]),
     
-    (tfhConfig(infer_datetimes=True), '5p', datetime.datetime(2018, 8, 4, 17, 0)),
-    (tfhConfig(infer_datetimes=False), '5p', datetime.time(hour=17, minute=0)),
-    (tfhConfig(infer_datetimes=True), '1p', datetime.datetime(2018, 8, 5, 13, 0)), # gh#12
+    (tfhConfig(infer_datetimes=True), '5p', [datetime.datetime(2018, 8, 4, 17, 0)]),
+    (tfhConfig(infer_datetimes=False), '5p', [datetime.time(hour=17, minute=0)]),
+    (tfhConfig(infer_datetimes=True), '1p', [datetime.datetime(2018, 8, 5, 13, 0)]), # gh#12
 ])
 def test_custom_config(now, config, test_input, expected):
     config.now = now
@@ -217,13 +217,13 @@ def test_timezone(now):  # gh#52
     now_PST = now.replace(tzinfo=pytz.timezone('US/Pacific'))
     
     # 1. When a timezone is specified in the original text, honor this first.
-    assert timefhuman('Wed EST', tfhConfig(now=now_PST)) == datetime.datetime(2018, 8, 8, 0, 0, tzinfo=pytz.timezone('US/Michigan'))
-    assert timefhuman('Wed 5p EST', tfhConfig(now=now_PST)) == datetime.datetime(2018, 8, 8, 17, 0, tzinfo=pytz.timezone('US/Michigan'))
-    assert timefhuman('5p EST', tfhConfig(now=now_PST)) == datetime.datetime(2018, 8, 4, 17, 0, tzinfo=pytz.timezone('US/Michigan'))
-    assert timefhuman('5p EST', tfhConfig(now=now_PST, direction=Direction.previous)) == datetime.datetime(2018, 8, 3, 17, 0, tzinfo=pytz.timezone('US/Michigan'))
-    assert timefhuman('9a EST', tfhConfig(now=now_PST, direction=Direction.next)) == datetime.datetime(2018, 8, 5, 9, 0, tzinfo=pytz.timezone('US/Michigan'))
-    assert timefhuman('9a EST', tfhConfig(now=now_PST, infer_datetimes=False)) == datetime.time(9, 0, tzinfo=pytz.timezone('US/Michigan'))
+    assert timefhuman('Wed EST', tfhConfig(now=now_PST)) == [datetime.datetime(2018, 8, 8, 0, 0, tzinfo=pytz.timezone('US/Michigan'))]
+    assert timefhuman('Wed 5p EST', tfhConfig(now=now_PST)) == [datetime.datetime(2018, 8, 8, 17, 0, tzinfo=pytz.timezone('US/Michigan'))]
+    assert timefhuman('5p EST', tfhConfig(now=now_PST)) == [datetime.datetime(2018, 8, 4, 17, 0, tzinfo=pytz.timezone('US/Michigan'))]
+    assert timefhuman('5p EST', tfhConfig(now=now_PST, direction=Direction.previous)) == [datetime.datetime(2018, 8, 3, 17, 0, tzinfo=pytz.timezone('US/Michigan'))]
+    assert timefhuman('9a EST', tfhConfig(now=now_PST, direction=Direction.next)) == [datetime.datetime(2018, 8, 5, 9, 0, tzinfo=pytz.timezone('US/Michigan'))]
+    assert timefhuman('9a EST', tfhConfig(now=now_PST, infer_datetimes=False)) == [datetime.time(9, 0, tzinfo=pytz.timezone('US/Michigan'))]
     # 2. Otherwise, if a timezone is specified in `now`, use this.
-    assert timefhuman('Wed', tfhConfig(now=now_PST)) == datetime.datetime(2018, 8, 8, 0, 0, tzinfo=pytz.timezone('US/Pacific'))
+    assert timefhuman('Wed', tfhConfig(now=now_PST)) == [datetime.datetime(2018, 8, 8, 0, 0, tzinfo=pytz.timezone('US/Pacific'))]
     # 3. If no timezone is specified, do not attach one
-    assert timefhuman('Wed', tfhConfig(now=now)) == datetime.datetime(2018, 8, 8, 0, 0)
+    assert timefhuman('Wed', tfhConfig(now=now)) == [datetime.datetime(2018, 8, 8, 0, 0)]

--- a/timefhuman/main.py
+++ b/timefhuman/main.py
@@ -48,9 +48,6 @@ def timefhuman(string, config: tfhConfig = tfhConfig(), raw: bool=False, now: bo
         positions = [(renderer.matched_text_pos[0], renderer.matched_text_pos[1]) for renderer in renderers]
         matched_texts = [string[start: end] for start, end in positions]
         return list(zip(matched_texts, positions, datetimes))
-    
-    if config.return_single_object and len(datetimes) == 1:
-        return datetimes[0]
     return datetimes
 
 

--- a/timefhuman/utils.py
+++ b/timefhuman/utils.py
@@ -21,7 +21,8 @@ class tfhConfig:
     direction: Direction = Direction.next
     
     # Always produce datetime objects. If no date, use the current date. If no time, use midnight.
-    # If timedelta, add it to the current datetime.
+    # If timedelta, add it to the current datetime. Still allows ranges (tuples) of datetimes and
+    # lists of datetimes.
     infer_datetimes: bool = True
     
     # The 'current' datetime, used if infer_datetimes is True
@@ -29,9 +30,6 @@ class tfhConfig:
     
     # Return the matched text from the input string
     return_matched_text: bool = False
-    
-    # Return a single object instead of a list when there's only one match
-    return_single_object: bool = True
 
 
 def generate_timezone_mapping():


### PR DESCRIPTION
No more `return_single_object`, which would muddle the possible return types.

Now, `timefhuman` can only return lists (datetimes, lists of datetimes, or ranges of datetimes)