### PR TITLE
[grammar] Stricter UNK token

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -181,6 +181,9 @@ def test_custom_config(now, config, test_input, expected):
     ]),
     ('There are 3 ways to do it', []),  # '3' should remain ambiguous and then be ignored
     ('salmon for 9 amnesty tickets', []),  # no date or time (contains 'mon' and '9 am')
+    ('s 1/1/24 C', [
+        ('1/1/24', (2, 7), datetime.datetime(2024, 1, 1, 0, 0))
+    ]),
 ])
 def test_matched_text(now, test_input, expected):  # gh#9
     assert timefhuman(test_input, tfhConfig(now=now, return_matched_text=True)) == expected

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -182,7 +182,7 @@ def test_custom_config(now, config, test_input, expected):
     ('There are 3 ways to do it', []),  # '3' should remain ambiguous and then be ignored
     ('salmon for 9 amnesty tickets', []),  # no date or time (contains 'mon' and '9 am')
     ('s 1/1/24 C', [
-        ('1/1/24', (2, 7), datetime.datetime(2024, 1, 1, 0, 0))
+        ('1/1/24', (2, 8), datetime.datetime(2024, 1, 1, 0, 0))
     ]),
 ])
 def test_matched_text(now, test_input, expected):  # gh#9

--- a/timefhuman/grammar.lark
+++ b/timefhuman/grammar.lark
@@ -26,7 +26,7 @@ DATETIMENAME: /(?i)(?<![a-z])(tonight)(?![a-z])/
 
 // Duration unit (minutes, hours, days, etc.)
 DURATION_UNIT: /(?i)(?<![a-z])(seconds|second|secs|sec|minutes|mins|min|hours|hour|hrs|hr|h|days|day|weeks|week|wks|wk|months|month|mos|years|year)(?![a-z])/
-DURATION_UNIT_LETTER: /(?i)(?<![a-z])(s|m|h|d|w|mo|y)(?![a-z])/
+DURATION_UNIT_LETTER: /(?i)(?<=\d)(s|m|h|d|w|mo|y)(?![a-z])/
 
 // Duration number (digits like "1", or words like "an", "a", "one", "two", etc.)
 DURATION_NUMBER: /(?i)(?<![a-z])(an|a|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety)(?![a-z])/
@@ -77,8 +77,10 @@ datetime: date ("at" (time | houronly))? timezone?
 // won't be processed until the date rule. If additional modifiers are added,
 // update the date rule processor to handle them. It currently assumes that only
 // the month can be modified.
-date: weekday? month "/" day "/" year
-    | weekday? year "/" month "/" day
+!date_mdy: weekday? month "/" day "/" year -> date
+!date_ymd: weekday? year "/" month "/" day -> date
+date: date_mdy
+    | date_ymd
     | weekday? month "/" dayoryear
     | weekday? month "-" day "-" year
     | weekday? year "-" month "-" day

--- a/timefhuman/grammar.lark
+++ b/timefhuman/grammar.lark
@@ -135,4 +135,5 @@ position: POSITION
 
 ambiguous: INT
 
-unknown: /[^\s:]/
+// catch stray punctuation/letters without interfering with digits/slashes
+unknown: /(?i)[^\s\d:\/]/


### PR DESCRIPTION
Prevents stray tokens from interfering with lexing. Fixes https://github.com/alvinwan/timefhuman/issues/71