### PR TITLE
Fix date parsing for weekday/day/month order

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -15,6 +15,7 @@ import pytz
     ('7-17-18', [datetime.datetime(2018, 7, 17, 0, 0)]),
     ('2018-7-17', [datetime.datetime(2018, 7, 17, 0, 0)]),  # support YMD
     ('7/2018', [datetime.datetime(2018, 7, 1, 0, 0)]),
+    ('Wed 25 Jun', [datetime.datetime(2018, 6, 25, 0, 0)]),
     
     # datetimes
     ('July 17, 2018 at 3p.m.', [datetime.datetime(2018, 7, 17, 15, 0)]),
@@ -87,6 +88,7 @@ def test_default(now, test_input, expected):
     ('July 2019', [datetime.date(2019, 7, 1)]),
     ('Sunday 7/7/2019', [datetime.date(2019, 7, 7)]),  # fixes gh#27
     ('1/1/95', [datetime.date(1995, 1, 1)]),
+    ('Wed 25 Jun', [datetime.date(2018, 6, 25)]),
     
     # date-only ranges
     ('7/17-7/18', [(datetime.date(2018, 7, 17), datetime.date(2018, 7, 18))]),

--- a/timefhuman/grammar.lark
+++ b/timefhuman/grammar.lark
@@ -91,6 +91,8 @@ date: date_mdy
     | weekday? monthname day DAY_SUFFIX? (",")? year
     | weekday? monthname day DAY_SUFFIX
     | weekday? day DAY_SUFFIX
+    | weekday? day DAY_SUFFIX? monthname (",")? year
+    | weekday? day DAY_SUFFIX? monthname
     | weekday? monthname dayoryear
     | modifier+ monthname
     | position weekday ("of"|"in") monthname


### PR DESCRIPTION
## Summary
- support date expressions like `Wed 25 Jun`
- test coverage for weekday-day-month formats in both inference modes

fixes #82 

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68709f455694832abeacb99d0e3249f3