### PR TITLE
Fix parsing of times with trailing punctuation

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -197,3 +197,13 @@ def test_custom_config(now, config, test_input, expected):
 ])
 def test_matched_text(now, test_input, expected):  # gh#9
     assert timefhuman(test_input, tfhConfig(now=now, return_matched_text=True)) == expected
+
+
+def test_question_mark_meridiem(now):
+    assert timefhuman(
+        'Are you free this Wed at 3p? Or maybe Fri at 5p?',
+        tfhConfig(now=now)
+    ) == [
+        datetime.datetime(2018, 8, 8, 15, 0),
+        datetime.datetime(2018, 8, 10, 17, 0)
+    ]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -53,6 +53,10 @@ import pytz
     # choices
     ('July 4th or 5th at 3PM', [[datetime.datetime(2018, 7, 4, 15, 0), datetime.datetime(2018, 7, 5, 15, 0)]]), # distribute month and time
     ('tomorrow noon,Wed 3 p.m.,Fri 11 AM', [[datetime.datetime(2018, 8, 5, 12, 0), datetime.datetime(2018, 8, 8, 15, 0), datetime.datetime(2018, 8, 10, 11, 0)]]), # distribute meridiem
+    ('Are you free this Wed at 3p? Or maybe Fri at 5p?', [
+        datetime.datetime(2018, 8, 8, 15, 0),
+        datetime.datetime(2018, 8, 10, 17, 0),
+    ]),
     # ('2, 3, or 4p tmw', [datetime.datetime(2018, 8, 4, 2, 0), datetime.datetime(2018, 8, 4, 3, 0), datetime.datetime(2018, 8, 4, 4, 0)]), # multiple ambiguous tokens #TODO (check month?)
     
     # choices of ranges
@@ -199,11 +203,3 @@ def test_matched_text(now, test_input, expected):  # gh#9
     assert timefhuman(test_input, tfhConfig(now=now, return_matched_text=True)) == expected
 
 
-def test_question_mark_meridiem(now):
-    assert timefhuman(
-        'Are you free this Wed at 3p? Or maybe Fri at 5p?',
-        tfhConfig(now=now)
-    ) == [
-        datetime.datetime(2018, 8, 8, 15, 0),
-        datetime.datetime(2018, 8, 10, 17, 0)
-    ]

--- a/timefhuman/grammar.lark
+++ b/timefhuman/grammar.lark
@@ -141,4 +141,5 @@ position: POSITION
 ambiguous: INT
 
 // catch stray punctuation/letters without interfering with digits/slashes
-unknown: /(?i)[^\s\d:\/\-]/
+// Set low priority so that keywords like "at" or "or" take precedence
+unknown.-1: /(?i)[^\s\d:\/\-]/


### PR DESCRIPTION
## Summary
- ensure punctuation like `?` after times doesn't break matching
- cover the case in unit tests

fixes #69 

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a68c0c84832a9e987922834e772d